### PR TITLE
Remove non-bluecore Alma institutions

### DIFF
--- a/ils_middleware/dags/alma.py
+++ b/ils_middleware/dags/alma.py
@@ -47,19 +47,7 @@ default_args = {
 
 institutions = [
     "ucdavis",
-    "princeton",
     "penn",
-    "northwestern",
-    "newcastle",
-    "dnal",
-    "memorial",
-    "miami",
-    "leeds",
-    "harvard",
-    "emory",
-    "jmu",
-    "brandeis",
-    "PUC",
 ]
 
 


### PR DESCRIPTION
I used the list of bluecore institutions at https://bluecore.info/#partner-libraries

Closes #15
