### PR TITLE
Publish Docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Build and Release Docker Image
+
+on:
+  release:
+    types:
+      published
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and push Docker image
+        run: |
+          docker login --username blue-core-lod --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          docker build . --tag ghcr.io/blue-core-lod/bluecore-workflows:latest
+          docker push ghcr.io/blue-core-lod/bluecore-workflows:latest


### PR DESCRIPTION
When a new release is published in Github a new Docker image for the repo will be published to Github Container Registry:

    ghcr.io/blue-core-lod/bluecore-workflows:latest

I tested by having it run on a push, and you can see the resulting Docker image here:

https://github.com/orgs/blue-core-lod/packages

I'm assuming that we want to make the images public so that we can use them easily in our Terraform environment? Alternatively we could keep them private and then ensure that our Terraform environment authenticates with a token with sufficient privileges. 

Only the Github organization administrator for blue-core has permission to make the image public. 

<img width="1711" alt="Screenshot 2025-04-23 at 4 21 41 PM" src="https://github.com/user-attachments/assets/46dc560a-4cf3-4637-8cca-96607cf9fe7f" />

Closes #19
