### PR TITLE
35: removed redundant constant and replaced with better pattern in place

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -17,7 +17,6 @@ x-keycloak-env: &keycloak-env
   KEYCLOAK_REALM: 'bluecore'
   KEYCLOAK_INTERNAL_URL: 'http://keycloak:8080/keycloak/'
   KEYCLOAK_EXTERNAL_URL: 'http://localhost:8081/keycloak/'
-  AIRFLOW_KEYCLOAK_REALM: 'bluecore'
   AIRFLOW_KEYCLOAK_CLIENT_ID: 'bluecore_workflows'
   AIRFLOW_KEYCLOAK_CLIENT_SECRET: 'KIu8gWa8rtjlT0Zl7zkNzsObFZGJ2IsJ' # Replace with your actual secret (Need to be set in Keycloak)
   # ----------------------------------

--- a/config/webserver_config.py
+++ b/config/webserver_config.py
@@ -51,7 +51,7 @@ AUTH_ROLES_MAPPING = {
 # Pull .env constants ==========================================================
 CLIENT_ID = os.getenv("AIRFLOW_KEYCLOAK_CLIENT_ID")
 CLIENT_SECRET = os.getenv("AIRFLOW_KEYCLOAK_CLIENT_SECRET")
-REALM = os.getenv("AIRFLOW_KEYCLOAK_REALM")
+REALM = os.getenv("KEYCLOAK_REALM")
 KEYCLOAK_INTERNAL_URL = os.getenv("KEYCLOAK_INTERNAL_URL")
 KEYCLOAK_EXTERNAL_URL = os.getenv("KEYCLOAK_EXTERNAL_URL")
 

--- a/tests/keycloak/test_webserver_config.py
+++ b/tests/keycloak/test_webserver_config.py
@@ -43,7 +43,7 @@ def test_keycloak_token_flow_and_jwt_decoding(mock_jwt_decode, httpx_mock, monke
     monkeypatch.setenv("KEYCLOAK_EXTERNAL_URL", "http://localhost:8081/keycloak/")
     monkeypatch.setenv("AIRFLOW_KEYCLOAK_CLIENT_ID", CLIENT_ID)
     monkeypatch.setenv("AIRFLOW_KEYCLOAK_CLIENT_SECRET", "mocked_client_secret")
-    monkeypatch.setenv("AIRFLOW_KEYCLOAK_REALM", "bluecore")
+    monkeypatch.setenv("KEYCLOAK_REALM", "bluecore")
 
     # Build a test public key, DER → Base64
     test_public_key = rsa.generate_private_key(


### PR DESCRIPTION
## Why was this change made?
This was made to reduce unnecessary variable names since all realms will be bluecore


## How was this change tested?
tested locally


## Which documentation and/or configurations were updated?
* updated `webserver_config.py`  to use  `KEYCLOAK_REALM` instead of `AIRFLOW_KEYCLOAK_REALM`



