### PR TITLE
50/48/populate UUID for batch load

### DIFF
--- a/ils_middleware/tasks/bluecore/batch.py
+++ b/ils_middleware/tasks/bluecore/batch.py
@@ -92,7 +92,7 @@ def parse_file_to_graph(file_str: str) -> List[Dict[str, Any]]:
             logger.info(f"Instance {instance} is a blank node, not processing")
             continue
         instance_graph = generate_entity_graph(file_graph, instance)
-        updated_payload: Dict[str, Any] = handle_external_subject(
+        updated_payload = handle_external_subject(
             data=instance_graph.serialize(format="json-ld"),
             type="instances",
             bluecore_base_url=BLUECORE_URL,

--- a/ils_middleware/tasks/bluecore/batch.py
+++ b/ils_middleware/tasks/bluecore/batch.py
@@ -27,9 +27,13 @@ def _add_other_resources(**kwargs):
     entity: str = kwargs["entity"]
     resources: List[Dict[str, Any]] = kwargs["resources"]
     entity_graph_str = json.dumps(entity_graph_dict)
-    entity_graph: rdflib.Graph = rdflib.Graph().parse(data=entity_graph_str, format="json-ld")
+    entity_graph: rdflib.Graph = rdflib.Graph().parse(
+        data=entity_graph_str, format="json-ld"
+    )
     entity = rdflib.URIRef(entity)
-    other_resources: List[Dict[str, str]] = generate_other_resources(file_graph, entity_graph)
+    other_resources: List[Dict[str, str]] = generate_other_resources(
+        file_graph, entity_graph
+    )
     for resource in other_resources:
         # This data for other_resources is not framed.
         new_resource: Dict[str, Any] = json.loads(resource["graph"])
@@ -41,6 +45,7 @@ def _add_other_resources(**kwargs):
                 "bibframe_resource_uri": str(entity),
             }
         )
+
 
 def is_zip(file_name: str) -> bool:
     """Determines if file is a zip file"""

--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -47,7 +47,9 @@ def store_bluecore_resources(**kwargs):
                     )
                     if not instance:
                         instance = Instance(
-                            uri=payload["uri"], data=payload["resource"], uuid=payload["uuid"]
+                            uri=payload["uri"],
+                            data=payload["resource"],
+                            uuid=payload["uuid"],
                         )
                         if "work_uri" in payload:
                             db_work = (
@@ -85,7 +87,11 @@ def store_bluecore_resources(**kwargs):
                 case "Work":
                     work = session.query(Work).where(Work.uri == payload["uri"]).first()
                     if not work:
-                        work = Work(uri=payload["uri"], data=payload["resource"], uuid=payload["uuid"])
+                        work = Work(
+                            uri=payload["uri"],
+                            data=payload["resource"],
+                            uuid=payload["uuid"],
+                        )
                         session.add(work)
 
                 case _:

--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -47,7 +47,7 @@ def store_bluecore_resources(**kwargs):
                     )
                     if not instance:
                         instance = Instance(
-                            uri=payload["uri"], data=payload["resource"]
+                            uri=payload["uri"], data=payload["resource"], uuid=payload["uuid"]
                         )
                         if "work_uri" in payload:
                             db_work = (
@@ -85,7 +85,7 @@ def store_bluecore_resources(**kwargs):
                 case "Work":
                     work = session.query(Work).where(Work.uri == payload["uri"]).first()
                     if not work:
-                        work = Work(uri=payload["uri"], data=payload["resource"])
+                        work = Work(uri=payload["uri"], data=payload["resource"], uuid=payload["uuid"])
                         session.add(work)
 
                 case _:

--- a/tests/tasks/bluecore/test_batch.py
+++ b/tests/tasks/bluecore/test_batch.py
@@ -23,6 +23,8 @@ def test_parse_file_to_graph(test_graph, tmp_path):
     assert resources[0]["class"].startswith("Work")
     # TODO when we have BlueCore URL schema, should replace Sinopia fixture URLs with BlueCore URLs
     assert resources[0]["uri"].startswith("https://bcld.info/works")
+    expected_uuid = resources[0]["uri"].split("/")[-1]
+    assert resources[0]["uuid"] == expected_uuid
     assert resources[1]["bibframe_resource_uri"] == str(resources[0]["uri"])
     assert resources[13]["class"].startswith("Instance")
     assert resources[14]["bibframe_resource_uri"] == str(resources[13]["uri"])


### PR DESCRIPTION
## Why was this change made?
- Populate uuid field for works/instances for batch load.
- Fix data for other_resources to be stored as dict (issue #48) as well - this data is not framed


## How was this change tested?
Loaded data locally


## Which documentation and/or configurations were updated?
N/A



