### PR TITLE
Release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.3.0"
+version = "0.4.0"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]
@@ -21,7 +21,7 @@ dependencies = [
     "pendulum",
     "psycopg2-binary>=2.9.10",
     "boto3",
-    "bluecore-models>=0.8.1",
+    "bluecore-models",
     "xmlsec==1.3.14", # this pin can be released once a package issue with 1.3.15 is resolved
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },
@@ -536,7 +536,7 @@ requires-dist = [
     { name = "apache-airflow", specifier = "==3.0.2" },
     { name = "apache-airflow-providers-amazon" },
     { name = "apache-airflow-providers-fab" },
-    { name = "bluecore-models", specifier = ">=0.8.1" },
+    { name = "bluecore-models" },
     { name = "boto3" },
     { name = "folio-uuid" },
     { name = "folioclient" },


### PR DESCRIPTION
## Why was this change made?

So we can build an image and get the new bluecore-models out into our "prod" environment. I also let bluecore-models float in the pyproject.toml since it is pinned in uv.lock.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a




