### PR TITLE
Disable Keycloak HTTPS in dev

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -72,6 +72,7 @@ x-keycloak-env: &keycloak-env
   KC_PROXY_HEADERS: 'xforwarded'
   KC_PROXY: 'edge'
   KC_HTTP_ENABLED: 'true'
+  KC_HTTPS_ENABLED: 'false'
   KC_HTTP_RELATIVE_PATH: '/keycloak/'
   KC_LOG_LEVEL: 'INFO'
 


### PR DESCRIPTION
## Why was this change made?

I was getting a HTTPS required error when trying to login to Keycloak from Airflow running on http://localhost:8080 after updating to the latest code and images. It seems setting this additional environment variable fixes it.

Before I made this change I was seeing this error when clicking to login at http://localhost:8080/

<img width="1418" height="896" alt="Screenshot 2025-08-25 at 11 04 35 AM" src="https://github.com/user-attachments/assets/7603db79-656b-49cd-9037-c19f77b83af3" />

## How was this change tested?

Running `docker compose up` and trying to login.

## Which documentation and/or configurations were updated?

n/a




