### PR TITLE
46 add keycloak user id to versions

### DIFF
--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -17,6 +17,7 @@ def get_bluecore_db():
 )
 def store_bluecore_resources(**kwargs):
     import logging
+
     logger = logging.getLogger(__name__)
     if not logger.handlers:
         logging.basicConfig(level=logging.INFO)

--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -27,6 +27,7 @@ def store_bluecore_resources(**kwargs):
         versions.keycloak_user_id during ORM events triggered by inserts/updates.
         """
         from bluecore_models.models.version import CURRENT_USER_ID
+
         uid = kwargs.get("user_uid")
         CURRENT_USER_ID.set(uid)
         print("Using CURRENT_USER_ID: ", uid)

--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -37,7 +37,7 @@ def store_bluecore_resources(**kwargs):
         CURRENT_USER_ID.set(uid)
         logger.info("Using CURRENT_USER_ID: %s", uid)
     except Exception as e:
-        logger.exception("Failed to set CURRENT_USER_ID")
+        logger.error("Failed to set CURRENT_USER_ID: %s", e)
 
     from sqlalchemy import create_engine
     from sqlalchemy.orm import Session

--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -16,6 +16,10 @@ def get_bluecore_db():
     system_site_packages=False,
 )
 def store_bluecore_resources(**kwargs):
+    import logging
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(level=logging.INFO)
     """Stores Work or Instance in the Blue Core Database
 
     Note: Virtualenv is needed because bluecore.models uses SQLAlchemy 2.+
@@ -30,9 +34,9 @@ def store_bluecore_resources(**kwargs):
 
         uid = kwargs.get("user_uid")
         CURRENT_USER_ID.set(uid)
-        print("Using CURRENT_USER_ID: ", uid)
+        logger.info("Using CURRENT_USER_ID: %s", uid)
     except Exception as e:
-        print("Failed to set CURRENT_USER_ID: ", e)
+        logger.exception("Failed to set CURRENT_USER_ID")
 
     from sqlalchemy import create_engine
     from sqlalchemy.orm import Session

--- a/ils_middleware/tasks/bluecore/storage.py
+++ b/ils_middleware/tasks/bluecore/storage.py
@@ -21,6 +21,18 @@ def store_bluecore_resources(**kwargs):
     Note: Virtualenv is needed because bluecore.models uses SQLAlchemy 2.+
     and Airflow uses a 1.x version of SQLAlchemy
     """
+    try:
+        """
+        Set CURRENT_USER_ID from DAG-provided user_uid so #add_version can write
+        versions.keycloak_user_id during ORM events triggered by inserts/updates.
+        """
+        from bluecore_models.models.version import CURRENT_USER_ID
+        uid = kwargs.get("user_uid")
+        CURRENT_USER_ID.set(uid)
+        print("Using CURRENT_USER_ID: ", uid)
+    except Exception as e:
+        print("Failed to set CURRENT_USER_ID: ", e)
+
     from sqlalchemy import create_engine
     from sqlalchemy.orm import Session
     from bluecore_models.models import (

--- a/keycloak-export/bluecore-realm.json
+++ b/keycloak-export/bluecore-realm.json
@@ -705,7 +705,7 @@
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
     "redirectUris" : [ "http://localhost:4444/marva/*", "http://localhost:8080/auth/oauth-authorized/keycloak", "http://localhost/api/oauth-authorized/keycloak", "http://localhost:8080/oauth-authorized/keycloak" ],
-    "webOrigins" : [ "http:..localhost:4444", "/*" ],
+    "webOrigins" : [ "http://localhost:4444", "/*" ],
     "notBefore" : 0,
     "bearerOnly" : false,
     "consentRequired" : false,

--- a/keycloak-export/bluecore-realm.json
+++ b/keycloak-export/bluecore-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "none",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,
@@ -704,8 +704,8 @@
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "http://localhost:8080/auth/oauth-authorized/keycloak", "http://localhost/api/oauth-authorized/keycloak", "http://localhost:8080/oauth-authorized/keycloak" ],
-    "webOrigins" : [ "/*" ],
+    "redirectUris" : [ "http://localhost:4444/marva/*", "http://localhost:8080/auth/oauth-authorized/keycloak", "http://localhost/api/oauth-authorized/keycloak", "http://localhost:8080/oauth-authorized/keycloak" ],
+    "webOrigins" : [ "http:..localhost:4444", "/*" ],
     "notBefore" : 0,
     "bearerOnly" : false,
     "consentRequired" : false,
@@ -763,6 +763,7 @@
       "client.secret.creation.time" : "1746805333",
       "backchannel.logout.session.required" : "true",
       "frontchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
       "display.on.consent.screen" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false"
@@ -1548,7 +1549,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-full-name-mapper" ]
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
       }
     }, {
       "id" : "4a3137ea-778d-437c-ab89-cea18d91032a",
@@ -1599,7 +1600,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper" ]
       }
     }, {
       "id" : "d2f2ccdf-b76c-4973-89c2-b852171a9d85",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.4.1"
+version = "0.4.2"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.4.2"
+version = "0.4.3"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.9.2"
+version = "0.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -490,14 +490,14 @@ dependencies = [
     { name = "pymilvus", extra = ["model"] },
     { name = "rdflib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/2d/102e6552a6b0a1025b14110b7ff2d8e3ab5aac03ed739891597e357f7dce/bluecore_models-0.9.2.tar.gz", hash = "sha256:4653258a04f608e8107f14294389c98a2058b29adf524bfd110641d4369f1179", size = 79122, upload-time = "2025-07-29T13:23:09.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/9d/d66c87053b26dcc1b0f5b9316084771554b5a48e48c79a83759ee5857d18/bluecore_models-0.9.4.tar.gz", hash = "sha256:971e13be2d34fe8f831b3e6c8974a08705b1dbe1e3d976eb4874c022a8f29cfe", size = 83587, upload-time = "2025-09-30T18:27:27.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/97/72fb0a72160600c71be2cf0d17fadd25c0f49025e8aea7466c61ede22d73/bluecore_models-0.9.2-py3-none-any.whl", hash = "sha256:7362bd79028d553d648866155a108449d14ba226815dba40ff724b6d669d7277", size = 12908, upload-time = "2025-07-29T13:23:08.826Z" },
+    { url = "https://files.pythonhosted.org/packages/32/82/2559c34a6ffbd51f9a411c681de726d06c906f29cb3a19d578df12a55078/bluecore_models-0.9.4-py3-none-any.whl", hash = "sha256:cc7b57538f20f1db4ed72ef65a69d81a193df3199a51197e2d1a1d60070f5f9c", size = 13110, upload-time = "2025-09-30T18:27:26.095Z" },
 ]
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
# PR: Thread Keycloak User UID into Airflow DAGs and Resource Storage
### ⚠️ Relies on PR https://github.com/blue-core-lod/bluecore_api/pull/157 
## Purpose of this PR
This PR propagates the caller’s Keycloak `user_uid` through the Airflow ingestion DAG  from the API so that downstream tasks can persist the UID into `versions.keycloak_user_id`. This enables full traceability of which user initiated each workflow and version change.

## Key Changes
- **Ingest DAG (`record.py`)**
  - Added new task `get_keycloak_user_uid()` to extract `user_uid` from `dag_run.conf`.
  - Pass `user_uid` into `store_bluecore_resources` alongside `records` and `bluecore_db`.
  - Logs the UID for visibility during DAG runs.

- **Storage Task (`storage.py`)**
  - Before ORM operations, set `CURRENT_USER_ID` from the `user_uid` 
  - Ensures `add_version()` writes `versions.keycloak_user_id` when new versions are created during inserts/updates.

- **Keycloak Realm Config (`bluecore-realm.json`)**
  - Relaxed SSL requirement from `external` → `none` for local/dev.
  - Updated `redirectUris` to include `http://localhost:4444/marva/*`.
  - Updated `webOrigins` to allow `http://localhost:4444`.

- **Version bump**
  - `bluecore-workflows` → `0.4.2`.

## Backward Compatibility
- Default behavior preserved if no `user_uid` is passed (remains `None`).
- Realm config changes primarily affect local/dev setups; production realms can still enforce stricter SSL.

## Ops Notes
- Ensure DAG triggers from the API now include `user_uid` in `dag_run.conf`.
- Database migrations for `versions.keycloak_user_id` must already be applied from `bluecore-models`.
- API changes from PR https://github.com/blue-core-lod/bluecore_api/pull/157 must already be merged and deployed before this will work
- Local/dev Keycloak config may need re-import due to realm JSON changes.
