### PR TITLE
Add slack webhook to dependency updates

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -62,6 +62,7 @@ jobs:
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
+        id: create_pr
         if: steps.check_changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
@@ -76,3 +77,14 @@ jobs:
             - Bumped patch version to `${{ steps.bump_version.outputs.new_version }}`
           commit-message: 'Update dependencies and bump patch version to ${{ steps.bump_version.outputs.new_version }}'
           labels: dependencies
+
+      - name: Notify Slack
+        if: steps.check_changes.outputs.changed == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}
+          NEW_VERSION: ${{ steps.bump_version.outputs.new_version }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"bluecore-workflows dependency update PR opened: <$PR_URL|v$NEW_VERSION>\"}" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Why was this change made?
To notify developers via slack webhook that there is a dependency update PR to review and merge.


## How was this change tested?
N/A


## Which documentation and/or configurations were updated?
N/A



