### PR TITLE
Do not create a dependency update PR if tests fail

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Bump patch version
         id: bump_version
-        if: steps.check_changes.outputs.changed == 'true'
+        if: steps.check_changes.outputs.changed == 'true' && success()
         run: |
           NEW_VERSION=$(python3 -c "
           import re
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create Pull Request
         id: create_pr
-        if: steps.check_changes.outputs.changed == 'true'
+        if: steps.check_changes.outputs.changed == 'true' && success()
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
           labels: dependencies
 
       - name: Notify Slack
-        if: steps.check_changes.outputs.changed == 'true'
+        if: steps.check_changes.outputs.changed == 'true' && success()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Bump patch version
         id: bump_version
-        if: steps.check_changes.outputs.changed == 'true' && success()
+        if: steps.check_changes.outputs.changed == 'true'
         run: |
           NEW_VERSION=$(python3 -c "
           import re
@@ -84,7 +84,19 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}
           NEW_VERSION: ${{ steps.bump_version.outputs.new_version }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\": \"bluecore-workflows dependency update PR opened: <$PR_URL|v$NEW_VERSION>\"}" \
+            --data "{\"text\": \"$REPO_NAME dependency update PR opened: <$PR_URL|v$NEW_VERSION>\"}" \
+            "$SLACK_WEBHOOK_URL"
+
+      - name: Notify Slack on test failure
+        if: steps.check_changes.outputs.changed == 'true' && failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"$REPO_NAME dependency update failed: <$RUN_URL|view run>\"}" \
             "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Why was this change made?
Blocks PR from being made if tests do not pass.
Notify on slack when tests fail for dependency updates


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a



