### PR TITLE
Extends FOLIO instance mapping

### DIFF
--- a/ils_middleware/tasks/bluecore.py
+++ b/ils_middleware/tasks/bluecore.py
@@ -39,7 +39,12 @@ def batch_archived_files(
         raise FileNotFoundError(f"{archive_file_path} does not exist")
 
     archive_file = tarfile.open(archive_file_path, "r")
-    file_names = archive_file.getnames()
+    file_names = [
+        name
+        for name in archive_file.getnames()
+        if rdflib.util.guess_format(name) is not None
+        and not pathlib.Path(name).name.startswith("._")
+    ]
 
     total_names = len(file_names)
     batch_size = int(total_names / number_of_batches)
@@ -152,7 +157,11 @@ def load_cbd_files(
 
     with tarfile.open(archived_file_path, "r") as cbd_archived_file:
         for i, name in enumerate(cbd_files):
+            if pathlib.Path(name).name.startswith("._"):
+                continue
             graph_format = rdflib.util.guess_format(name)
+            if graph_format is None:
+                continue
             graph = rdflib.Graph()
             cbd_file_buf = cbd_archived_file.extractfile(name)
             if cbd_file_buf is None:

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -178,7 +178,7 @@ def _notes(**kwargs) -> tuple:
             break
     notes = []
     for row in values:
-        notes.append({"instanceNoteId": note_id, "note": row[0], "staffOnly": False})
+        notes.append({"instanceNoteTypeId": note_id, "note": row[0], "staffOnly": False})
 
     return "notes", notes
 
@@ -212,10 +212,18 @@ def _publication(**kwargs) -> tuple:
 
 
 def _subjects(**kwargs) -> tuple:
+    folio_client = kwargs["folio_client"]
     values = kwargs["values"]
+
+    topical_term_type_id = None
+    for subject_type in folio_client.subject_types:
+        if subject_type["name"] == "Topical term":
+            topical_term_type_id = subject_type["id"]
+            break
+
     subjects = []
     for row in values:
-        subjects.append({"value": row[0]})
+        subjects.append({"value": row[0], "typeId": topical_term_type_id})
 
     return "subjects", subjects
 
@@ -225,7 +233,7 @@ def _genre(**kwargs) -> tuple:
     values = kwargs["values"]
 
     genre_form_type_id = None
-    for subject_type in folio_client.folio_get("/subject-types"):
+    for subject_type in folio_client.subject_types:
         if subject_type["name"] == "Genre/form":
             genre_form_type_id = subject_type["id"]
             break

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -21,6 +21,14 @@ def _default_transform(**kwargs) -> tuple:
     return folio_field, values
 
 
+def _editions(**kwargs) -> tuple:
+    values = kwargs["values"]
+    editions = kwargs["record"].get("editions", [])
+    for row in values:
+        editions.append(row[0])
+    return "editions", editions
+
+
 def _contributors(**kwargs) -> tuple:
     folio_client = kwargs["folio_client"]
     values = kwargs["values"]
@@ -52,6 +60,10 @@ def _contributors(**kwargs) -> tuple:
     return "contributors", contributors
 
 
+def _non_primary_contributor(**kwargs) -> tuple:
+    return _contributors(primary=False, contrib_name="Personal name", **kwargs)
+
+
 def _primary_contributor(**kwargs) -> tuple:
     return _contributors(primary=True, contrib_name="Personal name", **kwargs)
 
@@ -75,6 +87,8 @@ def _identifiers(**kwargs) -> tuple:
         identifier_name = "DOI"
     if folio_field.endswith("issn"):
         identifier_name = "ISSN"
+    if folio_field.endswith("local"):
+        identifier_name = "Local identifier"
 
     values = kwargs["values"]
 
@@ -201,18 +215,26 @@ def _subjects(**kwargs) -> tuple:
     values = kwargs["values"]
     subjects = []
     for row in values:
-        subjects.append(row[0])
+        subjects.append({"value": row[0]})
 
     return "subjects", subjects
 
 
-def genre(**kwargs) -> tuple:
+def _genre(**kwargs) -> tuple:
+    folio_client = kwargs["folio_client"]
     values = kwargs["values"]
-    genre = []
-    for row in values:
-        genre.append(row[0])
 
-    return "genre", genre
+    genre_form_type_id = None
+    for subject_type in folio_client.folio_get("/subject-types"):
+        if subject_type["name"] == "Genre/form":
+            genre_form_type_id = subject_type["id"]
+            break
+
+    subjects = kwargs["record"].get("subjects", [])
+    for row in values:
+        subjects.append({"value": row[0], "typeId": genre_form_type_id})
+
+    return "subjects", subjects
 
 
 def _title(**kwargs) -> tuple:
@@ -235,19 +257,25 @@ def _user_folio_id(okapi_url: str, folio_user: str) -> str:
 
 
 transforms = {
+    "contributor.Person": _non_primary_contributor,
+    "contributor.primary.Person": _primary_contributor,
+    "editions": _editions,
+    "editions.work": _editions,
     "identifiers.isbn": _identifiers,
     "identifiers.oclc": _identifiers,
     "identifiers.doi": _identifiers,
     "identifiers.lccn": _identifiers,
+    "identifiers.issn": _identifiers,
+    "identifiers.local": _identifiers,
     "instance_format": _instance_format_ids,
     "instance_type": _instance_type_id,
     "language": _language,
     "modeOfIssuanceId": _mode_of_issuance_id,
     "notes": _notes,
     "physical_description": _physical_descriptions,
-    "contributor.primary.Person": _primary_contributor,
     "publication": _publication,
     "subjects": _subjects,
+    "genre": _genre,
     "title": _title,
 }
 
@@ -292,13 +320,15 @@ def _inventory_record(**kwargs: Any) -> dict[str, Any]:
 
     for folio_field in FOLIO_FIELDS:
         post_processing = transforms.get(folio_field, _default_transform)
-        task_id = _task_ids(task_groups, folio_field)
-        raw_values = task_instance.xcom_pull(key=instance_uuid, task_ids=task_id)
-        if folio_field.startswith("instance_type") and len(raw_values) == 0:
-            raw_values = [["text"]]  # Default value
-        if raw_values:
+        bf_to_folio_task_id = _task_ids(task_groups, folio_field)
+        sparql_rows = task_instance.xcom_pull(
+            key=instance_uuid, task_ids=bf_to_folio_task_id
+        )
+        if folio_field.startswith("instance_type") and len(sparql_rows) == 0:
+            sparql_rows = [["text"]]  # Default value
+        if sparql_rows:
             record_field, values = post_processing(
-                values=raw_values,
+                values=sparql_rows,
                 okapi_url=folio_client.okapi_url,
                 folio_field=folio_field,
                 folio_user=folio_client.username,
@@ -307,7 +337,7 @@ def _inventory_record(**kwargs: Any) -> dict[str, Any]:
             )
 
             record[record_field] = values
-        logger.debug(f"{raw_values} values for {instance_uri}'s {task_id}")
+        logger.debug(f"{sparql_rows} values for {instance_uri}'s {bf_to_folio_task_id}")
     return record
 
 

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -178,7 +178,9 @@ def _notes(**kwargs) -> tuple:
             break
     notes = []
     for row in values:
-        notes.append({"instanceNoteTypeId": note_id, "note": row[0], "staffOnly": False})
+        notes.append(
+            {"instanceNoteTypeId": note_id, "note": row[0], "staffOnly": False}
+        )
 
     return "notes", notes
 

--- a/ils_middleware/tasks/folio/graph.py
+++ b/ils_middleware/tasks/folio/graph.py
@@ -21,7 +21,11 @@ def _build_graph(json_ld: list, instance_uri: str) -> tuple:
         raise ValueError(f"Instance {instance_uri} missing bf:instanceOf")
 
     # Retrieve JSON-LD from Work RDF
-    work_result = httpx.get(f"{work_uri}?expand=true", headers={"Accept": "application/ld+json"}, follow_redirects=True)
+    work_result = httpx.get(
+        f"{work_uri}?expand=true",
+        headers={"Accept": "application/ld+json"},
+        follow_redirects=True,
+    )
 
     if work_result.status_code > 399:
         raise ValueError(f"Error retrieving {work_uri}")

--- a/ils_middleware/tasks/folio/graph.py
+++ b/ils_middleware/tasks/folio/graph.py
@@ -21,7 +21,7 @@ def _build_graph(json_ld: list, instance_uri: str) -> tuple:
         raise ValueError(f"Instance {instance_uri} missing bf:instanceOf")
 
     # Retrieve JSON-LD from Work RDF
-    work_result = httpx.get(str(work_uri), headers={"Accept": "application/ld+json"})
+    work_result = httpx.get(f"{work_uri}?expand=true", headers={"Accept": "application/ld+json"}, follow_redirects=True)
 
     if work_result.status_code > 399:
         raise ValueError(f"Error retrieving {work_uri}")

--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -9,13 +9,22 @@ import ils_middleware.tasks.folio.mappings.bf_work as bf_work_map
 
 logger = logging.getLogger(__name__)
 
+# Order matters: fields that accumulate into the same FOLIO array (e.g. subjects/genre,
+# identifiers, editions) must be ordered so the first writer populates the list before
+# subsequent entries append to it via record.get(..., []).
 BF_TO_FOLIO_MAP = {
+    "contributor.Person": {
+        "template": bf_work_map.contributor,
+        "uri": "work",
+        "class": "bf:Person",
+    },
     "contributor.primary.Person": {
         "template": bf_work_map.primary_contributor,
         "uri": "work",
         "class": "bf:Person",
     },
     "editions": {"template": bf_instance_map.editions, "uri": "instance"},
+    "editions.work": {"template": bf_work_map.editions, "uri": "work"},
     "instance_format": {
         "template": bf_instance_map.instance_format_id,
         "uri": "instance",
@@ -44,6 +53,10 @@ BF_TO_FOLIO_MAP = {
         "template": bf_instance_map.identifier,
         "uri": "instance",
         "class": "bf:Issn",
+    },
+    "identifiers.local": {
+        "template": bf_instance_map.local_identifier,
+        "uri": "instance",
     },
     "instance_type": {"template": bf_work_map.instance_type_id, "uri": "work"},
     "language": {"template": bf_work_map.language, "uri": "work"},

--- a/ils_middleware/tasks/folio/mappings/bf_instance.py
+++ b/ils_middleware/tasks/folio/mappings/bf_instance.py
@@ -103,16 +103,26 @@ WHERE {{
 
 publication = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?publisher ?date ?place
 WHERE {{
    <{bf_instance}> a bf:Instance .
    <{bf_instance}> bf:provisionActivity ?activity .
    ?activity a bf:Publication .
-   ?activity bflc:simpleAgent ?publisher .
-   OPTIONAL {{ ?activity bflc:simpleDate ?date . }}
-   OPTIONAL {{ ?activity bflc:simplePlace ?place . }}
+   {{
+       ?activity bflc:simpleAgent ?publisher .
+       OPTIONAL {{ ?activity bflc:simpleDate ?date . }}
+       OPTIONAL {{ ?activity bflc:simplePlace ?place . }}
+   }} UNION {{
+       ?activity bf:agent ?agent_uri .
+       ?agent_uri rdfs:label ?publisher .
+       OPTIONAL {{ ?activity bf:date ?date . }}
+       OPTIONAL {{
+           ?activity bf:place ?place_uri .
+           ?place_uri rdfs:label ?place .
+       }}
+   }}
 }}
 """
 

--- a/ils_middleware/tasks/folio/mappings/bf_instance.py
+++ b/ils_middleware/tasks/folio/mappings/bf_instance.py
@@ -95,29 +95,24 @@ WHERE {{
     <{bf_instance}> bf:extent ?extent_bnode .
     ?extent_bnode a bf:Extent .
     ?extent_bnode rdfs:label ?extent .
-    <{bf_instance}> bf:dimensions ?dimensions .
+    OPTIONAL {{
+        <{bf_instance}> bf:dimensions ?dimensions .
+    }}
 }}
 """
 
 publication = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?publisher ?date ?place
 WHERE {{
    <{bf_instance}> a bf:Instance .
    <{bf_instance}> bf:provisionActivity ?activity .
    ?activity a bf:Publication .
-   ?activity bf:agent ?agent .
-   ?agent a bf:Agent .
-   ?agent rdfs:label ?publisher .
-   OPTIONAL {{
-      ?activity bf:date ?date .
-   }}
-   OPTIONAL {{
-      ?activity bf:place ?place_holder .
-      ?place_holder rdfs:label ?place .
-   }}
+   ?activity bflc:simpleAgent ?publisher .
+   OPTIONAL {{ ?activity bflc:simpleDate ?date . }}
+   OPTIONAL {{ ?activity bflc:simplePlace ?place . }}
 }}
 """
 

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -12,6 +12,7 @@ WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:contribution ?contrib_bnode .
     ?contrib_bnode a bf:Contribution .
+    FILTER NOT EXISTS {{ ?contrib_bnode a bf:PrimaryContribution }}
     ?contrib_bnode bf:role ?role_uri .
     ?role_uri rdfs:label ?role .
     ?contrib_bnode bf:agent ?agent_uri .

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -94,6 +94,5 @@ WHERE {{
     OPTIONAL {{
         ?genre_node rdfs:label ?genre .
     }}
-    
 }}
 """

--- a/ils_middleware/tasks/general/__init__.py
+++ b/ils_middleware/tasks/general/__init__.py
@@ -11,7 +11,11 @@ def get_resource(resource_uri: str) -> dict:
     Retrieves the Resource from Bluecore API using Sinopia header for
     URI and RDF data fields
     """
-    result = httpx.get(resource_uri, headers={"Accept": "application/vnd.sinopia+json"})
+    result = httpx.get(
+        resource_uri,
+        headers={"Accept": "application/vnd.sinopia+json"},
+        params={"expand": "true"},
+    )
     result.raise_for_status()
     return result.json()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.10.4"
+version = "0.11.0"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]

--- a/tests/fixtures/bf.ttl
+++ b/tests/fixtures/bf.ttl
@@ -82,10 +82,9 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
         [ a bf:Note ;
             rdfs:label "Description based on online resource (Stanford Digital Repository, viewed October 1, 2021)"@eng ] ;
     bf:provisionActivity [ a bf:Publication ;
-            bf:agent [ a bf:Agent ;
-                    rdfs:label "Edizioni Ca'Foscari"@eng ] ;
-            bf:date "2020"@eng ;
-            bf:place <http://id.loc.gov/authorities/names/n79018142> ] ;
+            bflc:simpleAgent "Edizioni Ca'Foscari" ;
+            bflc:simpleDate "2020" ;
+            bflc:simplePlace "Venice (Italy)" ] ;
     bf:provisionActivityStatement "Venezia : Edizioni Ca'Foscari, 2020"@ita ;
     bf:responsibilityStatement "Simone Brioni e Shirin Ramzanali Fazel"@ita ;
     bf:seriesStatement "Diaspore, 2610-9387 ;  13"@ita ;
@@ -140,4 +139,18 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
 <https://purl.stanford.edu/mf283yt5578> rdfs:label "Stanford Digital Repository"@eng .
 
 <http://id.loc.gov/vocabulary/relators/aut> rdfs:label "author" .
+
+<https://api.stage.sinopia.io/resource/pub-agent-oup> a bf:Organization ;
+    rdfs:label "Oxford University Press" .
+
+<https://api.stage.sinopia.io/resource/pub-place-oxford> a bf:Place ;
+    rdfs:label "Oxford (England)" .
+
+<https://api.stage.sinopia.io/resource/bf-agent-instance> a bf:Instance ;
+    bf:instanceOf <https://api.stage.sinopia.io/resource/c96d8b55-e0ac-48a5-9a9b-b0684758c99e> ;
+    bf:issuance <http://id.loc.gov/vocabulary/issuance/mono> ;
+    bf:provisionActivity [ a bf:Publication ;
+            bf:agent <https://api.stage.sinopia.io/resource/pub-agent-oup> ;
+            bf:date "2021" ;
+            bf:place <https://api.stage.sinopia.io/resource/pub-place-oxford> ] .
 

--- a/tests/tasks/folio/mappings/test_bf_instance.py
+++ b/tests/tasks/folio/mappings/test_bf_instance.py
@@ -6,6 +6,7 @@ import rdflib
 import ils_middleware.tasks.folio.mappings.bf_instance as bf_instance_map
 
 uri = "https://api.stage.sinopia.io/resource/b0319047-acd0-4f30-bd8b-98e6c1bac6b0"
+bf_agent_uri = "https://api.stage.sinopia.io/resource/bf-agent-instance"
 
 
 @typing.no_type_check
@@ -69,6 +70,16 @@ def test_publication(test_graph: rdflib.Graph):
     assert str(publications[0][0]).startswith("Edizioni Ca'Foscari")
     assert str(publications[0][1]).startswith("2020")
     assert str(publications[0][2]).startswith("Venice (Italy)")
+
+
+@typing.no_type_check
+def test_publication_bf_agent(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.publication.format(bf_instance=bf_agent_uri)
+    publications = [row for row in test_graph.query(sparql)]
+
+    assert str(publications[0][0]).startswith("Oxford University Press")
+    assert str(publications[0][1]).startswith("2021")
+    assert str(publications[0][2]).startswith("Oxford (England)")
 
 
 @typing.no_type_check

--- a/tests/tasks/folio/mappings/test_bf_work.py
+++ b/tests/tasks/folio/mappings/test_bf_work.py
@@ -67,3 +67,12 @@ def test_subject(test_graph: rdflib.Graph):
     subjects = [row for row in test_graph.query(sparql)]
 
     assert len(subjects) == 3
+
+
+@typing.no_type_check
+def test_genre(test_graph: rdflib.Graph):
+    sparql = bf_work_map.genre.format(bf_work=work_uri)
+
+    genres = [row for row in test_graph.query(sparql)]
+
+    assert str(genres[0][0]).startswith("Informational works")

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -14,12 +14,15 @@ from tasks import (
 import ils_middleware.tasks.folio.build as folio_build
 from ils_middleware.tasks.folio.build import (
     _default_transform,
+    _editions,
+    _genre,
     _identifiers,
     _instance_format_ids,
     _instance_type_id,
     _inventory_record,
     _language,
     _mode_of_issuance_id,
+    _non_primary_contributor,
     _notes,
     _physical_descriptions,
     _publication,
@@ -59,6 +62,7 @@ class MockFolioClient(object):
             {"id": "913300b2-03ed-469a-8179-c1092c991227", "name": "ISSN"},
             {"id": "c858e4f2-2b6b-4385-842b-60732ee14abb", "name": "LCCN"},
             {"id": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef", "name": "OCLC"},
+            {"id": "7e591197-f335-4afb-bc6d-a6d76ca3bace", "name": "Local identifier"},
         ]
 
         self.instance_formats = [
@@ -85,6 +89,10 @@ class MockFolioClient(object):
         get_response.text = json.dumps(folio_properties)
         if args[0].endswith("electronic-access-relationships"):
             return [{"name": "Resource", "id": "d2f38edc-b225-4cb4-a412-734d8bbbc855"}]
+        if args[0].endswith("subject-types"):
+            return [
+                {"name": "Genre/form", "id": "d6488f88-1e74-4674-9e7f-a294b9a6451d"}
+            ]
         return get_response
 
     def folio_put(self, *args, **kwargs):
@@ -347,10 +355,59 @@ def test_publication():
 
 
 def test_subjects():
-    subjects = _subjects(values=[["California"], ["Forest biodiversity"]])
-    assert (subjects[0]).startswith("subjects")
-    assert (subjects[1][0]).startswith("California")
-    assert (subjects[1][1]).startswith("Forest biodiversity")
+    subjects = _subjects(values=[["California"], ["Forest biodiversity"]], record={})
+    assert subjects[0] == "subjects"
+    assert subjects[1][0] == {"value": "California"}
+    assert subjects[1][1] == {"value": "Forest biodiversity"}
+
+
+def test_editions_accumulates():
+    _, instance_editions = _editions(values=[["First edition"]], record={})
+    _, merged = _editions(
+        values=[["Première édition"]], record={"editions": instance_editions}
+    )
+    assert len(merged) == 2
+    assert "First edition" in merged
+    assert "Première édition" in merged
+
+
+def test_non_primary_contributor():
+    field, contributors = _non_primary_contributor(
+        values=[["Butler, Octavia", "Author"]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert field == "contributors"
+    assert contributors[0]["primary"] is False
+    assert contributors[0]["name"] == "Butler, Octavia"
+
+
+def test_identifiers_local():
+    identifiers = _identifiers(
+        values=[["(OCoLC)1272909598"]],
+        folio_client=MockFolioClient(),
+        folio_field="identifiers.local",
+        record={},
+    )
+    assert identifiers[0] == "identifiers"
+    assert (
+        identifiers[1][0]["identifierTypeId"] == "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+    )
+    assert identifiers[1][0]["value"] == "(OCoLC)1272909598"
+
+
+def test_genre_merges_into_subjects():
+    existing_subjects = [{"value": "Mining engineering"}]
+    field, subjects = _genre(
+        values=[["Science fiction"]],
+        folio_client=MockFolioClient(),
+        record={"subjects": existing_subjects},
+    )
+    assert field == "subjects"
+    assert len(subjects) == 2
+    assert subjects[0] == {"value": "Mining engineering"}
+    assert subjects[1]["value"] == "Science fiction"
+    assert subjects[1]["typeId"] == "d6488f88-1e74-4674-9e7f-a294b9a6451d"
 
 
 def test_title_transform_all():

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -82,6 +82,10 @@ class MockFolioClient(object):
         self.instance_note_types = [
             {"id": "6a2533a7-4de2-4e64-8466-074c2fa9308c", "name": "General note"},
         ]
+        self.subject_types = [
+            {"id": "d6488f88-1e74-40ce-81b5-b19a928ff5b7", "name": "Topical term"},
+            {"id": "d6488f88-1e74-4674-9e7f-a294b9a6451d", "name": "Genre/form"},
+        ]
 
     def folio_get(self, *args, **kwargs):
         get_response = MagicMock()
@@ -331,7 +335,7 @@ def test_mode_of_issuance_id():
 def test_notes():  # noqa: F811
     notes = _notes(values=[["A great note"]], folio_client=MockFolioClient())
     assert (notes[0]).startswith("notes")
-    assert (notes[1][0]["instanceNoteId"]).startswith(
+    assert (notes[1][0]["instanceNoteTypeId"]).startswith(
         "6a2533a7-4de2-4e64-8466-074c2fa9308c"
     )
     assert (notes[1][0]["note"]).startswith("A great note")
@@ -355,10 +359,20 @@ def test_publication():
 
 
 def test_subjects():
-    subjects = _subjects(values=[["California"], ["Forest biodiversity"]], record={})
+    subjects = _subjects(
+        values=[["California"], ["Forest biodiversity"]],
+        record={},
+        folio_client=MockFolioClient(),
+    )
     assert subjects[0] == "subjects"
-    assert subjects[1][0] == {"value": "California"}
-    assert subjects[1][1] == {"value": "Forest biodiversity"}
+    assert subjects[1][0] == {
+        "value": "California",
+        "typeId": "d6488f88-1e74-40ce-81b5-b19a928ff5b7",
+    }
+    assert subjects[1][1] == {
+        "value": "Forest biodiversity",
+        "typeId": "d6488f88-1e74-40ce-81b5-b19a928ff5b7",
+    }
 
 
 def test_editions_accumulates():

--- a/tests/tasks/folio/test_graph.py
+++ b/tests/tasks/folio/test_graph.py
@@ -1,5 +1,6 @@
+import json
+
 import pytest
-import requests  # type: ignore
 
 from pytest_mock import MockerFixture
 from airflow.models.taskinstance import TaskInstance
@@ -20,8 +21,8 @@ mock_instance_doc = {
     }
 }
 
-mock_work = {
-    "data": [
+mock_work_jsonld = json.dumps(
+    [
         {
             "@id": "https://api.development.sinopia.io/resource/6497a461-42dc-42bf-b433-5e47c73f7e89",
             "@type": ["http://id.loc.gov/ontologies/bibframe/Work"],
@@ -44,7 +45,7 @@ mock_work = {
             ],
         },
     ]
-}
+)
 
 instance_uri = (
     "https://api.stage.sinopia.io/resource/8a2dda53-d3bc-485a-9154-635823045b4f"
@@ -56,14 +57,15 @@ work_uri = "https://api.sinopia.io/resources/not-found"
 def mock_requests(monkeypatch, mocker: MockerFixture):
     def mock_get(*args, **kwargs):
         get_response = mocker.stub(name="get_result")
-        if args[0] == work_uri:
+        url = args[0]
+        if url.startswith(work_uri):
             get_response.status_code = 401
         else:
             get_response.status_code = 200
-            get_response.json = lambda: mock_work
+            get_response.text = mock_work_jsonld
         return get_response
 
-    monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr("ils_middleware.tasks.folio.graph.httpx.get", mock_get)
 
 
 def test_construct_graph(mock_requests, mock_task_instance):  # noqa: F811

--- a/tests/tasks/general/test_init.py
+++ b/tests/tasks/general/test_init.py
@@ -60,5 +60,7 @@ def test_get_resource(mocker):
 
     assert result == {"uri": resource_uri}
     mock_get.assert_called_once_with(
-        resource_uri, headers={"Accept": "application/vnd.sinopia+json"}
+        resource_uri,
+        headers={"Accept": "application/vnd.sinopia+json"},
+        params={"expand": "true"},
     )

--- a/tests/tasks/test_bluecore.py
+++ b/tests/tasks/test_bluecore.py
@@ -32,7 +32,7 @@ def test_batch_archived_files(tmp_path):
         tar_file.add(test_cbd_files_dir)
 
     test_batches = batch_archived_files(str(archived_file_path))
-    assert len(test_batches) == 6
+    assert len(test_batches) == 5
     assert len(test_batches[0]) == 2_000
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.10.4"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
## Why was this change made?
Connects previously unused SPARQL queries, fix subjects/genre schema compliance, bug fixes for notes and publication mapping, and add corresponding tests.

Fixes #129 


## How was this change tested?
- Modified unit tests
- Did test workflow runs via Airflow -> FOLIO (See comments below with instances exported to folio)

## Which documentation and/or configurations were updated?
Adds comment to ils_middleware/tasks/folio/map.py about maintaining the order of `BF_TO_FOLIO_MAP`



