### PR TITLE
Adds Accept headers to Blue Core API calls

### DIFF
--- a/ils_middleware/tasks/amazon/alma_instance_s3.py
+++ b/ils_middleware/tasks/amazon/alma_instance_s3.py
@@ -22,10 +22,12 @@ def send_instance_to_alma_s3(**kwargs):
     bf = Namespace("http://id.loc.gov/ontologies/bibframe/")
 
     for instance_uri in resources:
-        instance_result = httpx.get(instance_uri)
+        instance_result = httpx.get(
+            instance_uri, headers={"Accept": "application/ld+json"}
+        )
         instance_uri = URIRef(instance_uri)
         work_uri = None
-        instance_graph = load_jsonld(instance_result.json()["data"])
+        instance_graph = load_jsonld(instance_result.json())
 
         # Bind the namespaces to the instance graph
         for prefix, url in alma_namespaces:

--- a/ils_middleware/tasks/amazon/alma_work_s3.py
+++ b/ils_middleware/tasks/amazon/alma_work_s3.py
@@ -20,8 +20,8 @@ def get_work_uri(instance_graph, instance_uri, bf):
 
 
 def parse_graph(uri):
-    resource_result = httpx.get(uri)
-    graph = load_jsonld(resource_result.json()["data"])
+    resource_result = httpx.get(uri, headers={"Accept": "application/ld+json"})
+    graph = load_jsonld(resource_result.json())
     return graph
 
 

--- a/ils_middleware/tasks/folio/graph.py
+++ b/ils_middleware/tasks/folio/graph.py
@@ -1,8 +1,9 @@
-import json
 import logging
 
+import httpx
 import rdflib
-import requests  # type: ignore
+
+from bluecore_models.utils.graph import load_jsonld
 
 logger = logging.getLogger(__name__)
 
@@ -12,8 +13,7 @@ BF = rdflib.Namespace("http://id.loc.gov/ontologies/bibframe/")
 def _build_graph(json_ld: list, instance_uri: str) -> tuple:
     """Builds RDF Graph from BF Instance's RDF and retrieves
     and parses RDF from Work"""
-    graph = rdflib.Graph()
-    graph.parse(data=json.dumps(json_ld), format="json-ld")
+    graph = load_jsonld(json_ld)
 
     work_uri = graph.value(subject=rdflib.URIRef(instance_uri), predicate=BF.instanceOf)
 
@@ -21,12 +21,12 @@ def _build_graph(json_ld: list, instance_uri: str) -> tuple:
         raise ValueError(f"Instance {instance_uri} missing bf:instanceOf")
 
     # Retrieve JSON-LD from Work RDF
-    work_result = requests.get(str(work_uri))
+    work_result = httpx.get(str(work_uri), headers={"Accept": "application/ld+json"})
 
     if work_result.status_code > 399:
         raise ValueError(f"Error retrieving {work_uri}")
 
-    graph.parse(data=json.dumps(work_result.json()["data"]), format="json-ld")
+    graph.parse(data=work_result.text, format="json-ld")
     logger.debug(f"Graph triples {len(graph)}")
     return graph, str(work_uri)
 

--- a/ils_middleware/tasks/general/__init__.py
+++ b/ils_middleware/tasks/general/__init__.py
@@ -7,8 +7,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_resource(resource_uri: str) -> dict:
-    """Retrieves the Resource from Bluecore API"""
-    result = httpx.get(resource_uri)
+    """
+    Retrieves the Resource from Bluecore API using Sinopia header for
+    URI and RDF data fields
+    """
+    result = httpx.get(resource_uri, headers={"Accept": "application/vnd.sinopia+json"})
     result.raise_for_status()
     return result.json()
 

--- a/tests/tasks/general/test_init.py
+++ b/tests/tasks/general/test_init.py
@@ -1,6 +1,10 @@
 import pytest
 
-from ils_middleware.tasks.general import message_from_context, parse_messages
+from ils_middleware.tasks.general import (
+    get_resource,
+    message_from_context,
+    parse_messages,
+)
 from tests.keycloak.server_mocks import mock_keycloak  # type: ignore # noqa: F401
 
 
@@ -45,3 +49,16 @@ def test_parse_messages(mocker, mock_keycloak):  # noqa: F811
     assert xcoms[0]["key"].endswith("7922d096-9b45-4235-be9a-a89d390bee83")
     assert xcoms[1]["value"][0].startswith("https://bcld.info/instance/7922d096")
     assert xcoms[2]["value"] == []
+
+
+def test_get_resource(mocker):
+    resource_uri = "https://bcld.info/instance/7922d096-9b45-4235-be9a-a89d390bee83"
+    mock_get = mocker.patch("ils_middleware.tasks.general.httpx.get")
+    mock_get.return_value.json.return_value = {"uri": resource_uri}
+
+    result = get_resource(resource_uri)
+
+    assert result == {"uri": resource_uri}
+    mock_get.assert_called_once_with(
+        resource_uri, headers={"Accept": "application/vnd.sinopia+json"}
+    )


### PR DESCRIPTION
## Why was this change made?
Fixes #134 

Retrieving Works and Instances without the Accept header returns the HTML view and we want json-ld or the Sinopia JSON payload.


## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
n/a



