### PR TITLE
Use bluecore-models v0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.11.0"
+version = "0.12.0"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]
@@ -21,7 +21,7 @@ dependencies = [
     "pendulum",
     "psycopg2-binary>=2.9.10",
     "boto3",
-    "bluecore-models",
+    "bluecore-models>=0.19.0",
     "xmlsec==1.3.14", # this pin can be released once a package issue with 1.3.15 is resolved
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -554,14 +554,14 @@ dependencies = [
     { name = "tenacity" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/3b/23bd1695228e0e3eadaf3b40d6fd5d3e8a7e7afa196597d31a27f9852893/bluecore_models-0.18.0.tar.gz", hash = "sha256:4c2219d439d088bfb848917cc492c1794c65807d58ba775d6c103ce0063d7e07", size = 168879, upload-time = "2026-06-25T21:18:17.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e8/0801ccb0124e896339d1cf310c38f89b58324e86954066ac9a75739f3fef/bluecore_models-0.19.0.tar.gz", hash = "sha256:5b810d71f67dd3a812ea341a5a43c11146c84b1a51e84759c83bb332bc0e6eb5", size = 170940, upload-time = "2026-06-30T19:08:28.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/6c/9b84e4e5acc37741ec07d583b07276644f01d27855e48b4a9eea9a57a1a5/bluecore_models-0.18.0-py3-none-any.whl", hash = "sha256:60514543d26c411f45288d3f88d1c519ec7373115c7409f63dffe2ab3e99eb8a", size = 33364, upload-time = "2026-06-25T21:18:16.794Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/7df173cf164fc6cc312aece2a641bb97a37d06cf741582c8deb4eacc732b/bluecore_models-0.19.0-py3-none-any.whl", hash = "sha256:66697522e748011494d65a8b14b5d7c847d776d82e4f269e8f3057acf07dff5e", size = 35938, upload-time = "2026-06-30T19:08:27.681Z" },
 ]
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },
@@ -600,7 +600,7 @@ requires-dist = [
     { name = "apache-airflow", specifier = "==3.2.0" },
     { name = "apache-airflow-providers-amazon" },
     { name = "apache-airflow-providers-fab" },
-    { name = "bluecore-models" },
+    { name = "bluecore-models", specifier = ">=0.19.0" },
     { name = "boto3" },
     { name = "folio-uuid" },
     { name = "folioclient" },


### PR DESCRIPTION
This needs to be merged after https://github.com/blue-core-lod/bluecore-models/pull/115 the tests won't pass until it is merged.

---

## Why was this change made?

For the new Profile model/schema.

## How was this change tested?

Local bluecore-stack

## Which documentation and/or configurations were updated?




