### PR TITLE
Adds missing fields to folio mapping

### DIFF
--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -79,7 +79,9 @@ def _alternative_titles(**kwargs) -> tuple:
             title = f"{title}. {row[2]}"
         if row[3]:  # partName
             title = f"{title}, {row[3]}"
-        alt_titles.append({"alternativeTitleTypeId": type_id, "alternativeTitle": title})
+        alt_titles.append(
+            {"alternativeTitleTypeId": type_id, "alternativeTitle": title}
+        )
 
     return "alternativeTitles", alt_titles
 

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -422,7 +422,9 @@ def _inventory_record(**kwargs: Any) -> dict[str, Any]:
     folio_client = kwargs["folio_client"]
 
     status_id = None
-    instance_status = folio_client.folio_get("instance-statuses", "instanceStatuses", "name==Cataloged")
+    instance_status = folio_client.folio_get(
+        "instance-statuses", "instanceStatuses", "name==Cataloged"
+    )
     if instance_status:
         status_id = instance_status[0]["id"]
 

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -61,7 +61,7 @@ def _alternative_titles(**kwargs) -> tuple:
     folio_field = kwargs["folio_field"]
     values = kwargs["values"]
 
-    subtype = folio_field.split(".")[-1]
+    subtype = folio_field.split(".")[1]
     type_name = _ALT_TITLE_TYPE_NAMES[subtype]
 
     type_id = None
@@ -280,6 +280,20 @@ def _publication_frequency(**kwargs) -> tuple:
     return "publicationFrequency", [row[0] for row in values]
 
 
+def _publication_range(**kwargs) -> tuple:
+    values = kwargs["values"]
+    output = []
+    for row in values:
+        first, last = row[0], row[1]
+        if first and last:
+            output.append(f"{first} - {last}")
+        elif first:
+            output.append(f"{first} -")
+        elif last:
+            output.append(f"- {last}")
+    return "publicationRange", output
+
+
 def _publication(**kwargs) -> tuple:
     values = kwargs["values"]
     publications = []
@@ -318,6 +332,30 @@ def _subjects(**kwargs) -> tuple:
         subjects.append({"value": row[0], "typeId": topical_term_type_id})
 
     return "subjects", subjects
+
+
+def _nature_of_content(**kwargs) -> tuple:
+    folio_client = kwargs["folio_client"]
+    values = kwargs["values"]
+
+    nature_terms = folio_client.folio_get(
+        "nature-of-content-terms",
+        "natureOfContentTerms",
+        query_params={"limit": 200},
+    )
+    lookup = {term["name"].casefold(): term["id"] for term in nature_terms}
+
+    term_ids = []
+    seen: set = set()
+    for row in values:
+        if row[0]:
+            label = str(row[0]).casefold()
+            for term_name, term_id in lookup.items():
+                if term_name in label and term_id not in seen:
+                    term_ids.append(term_id)
+                    seen.add(term_id)
+
+    return "natureOfContentTermIds", term_ids
 
 
 def _genre(**kwargs) -> tuple:
@@ -364,6 +402,9 @@ transforms = {
     "alternative_titles.abbreviated": _alternative_titles,
     "alternative_titles.parallel": _alternative_titles,
     "alternative_titles.variant": _alternative_titles,
+    "alternative_titles.abbreviated.work": _alternative_titles,
+    "alternative_titles.parallel.work": _alternative_titles,
+    "alternative_titles.variant.work": _alternative_titles,
     "contributor.Person": _non_primary_contributor,
     "contributor.primary.Person": _primary_contributor,
     "editions": _editions,
@@ -383,10 +424,12 @@ transforms = {
     "physical_description": _physical_descriptions,
     "publication": _publication,
     "publication_frequency": _publication_frequency,
+    "publication_range": _publication_range,
     "series.controlled": _series,
     "series.uncontrolled": _series,
     "subjects": _subjects,
     "genre": _genre,
+    "nature_of_content": _nature_of_content,
     "title": _title,
 }
 

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -14,11 +14,86 @@ from ils_middleware.tasks.folio.map import FOLIO_FIELDS
 logger = logging.getLogger(__name__)
 
 
+def _cataloged_date(**kwargs) -> tuple:
+    values = kwargs["values"]
+    return "catalogedDate", values[0][0]
+
+
+_CLASSIFICATION_TYPE_NAMES = {
+    "ddc": "Dewey",
+    "lcc": "LC",
+    "nlm": "NLM",
+}
+
+
+def _classifications(**kwargs) -> tuple:
+    folio_client = kwargs["folio_client"]
+    folio_field = kwargs["folio_field"]
+    values = kwargs["values"]
+
+    subtype = folio_field.split(".")[-1]
+    type_name = _CLASSIFICATION_TYPE_NAMES[subtype]
+
+    type_id = None
+    for row in folio_client.classification_types:
+        if row["name"] == type_name:
+            type_id = row["id"]
+            break
+
+    classifications = kwargs["record"].get("classifications", [])
+    for row in values:
+        classifications.append(
+            {"classificationNumber": row[0], "classificationTypeId": type_id}
+        )
+
+    return "classifications", classifications
+
+
+_ALT_TITLE_TYPE_NAMES = {
+    "abbreviated": "Abbreviated title",
+    "parallel": "Parallel title",
+    "variant": "Variant title",
+}
+
+
+def _alternative_titles(**kwargs) -> tuple:
+    folio_client = kwargs["folio_client"]
+    folio_field = kwargs["folio_field"]
+    values = kwargs["values"]
+
+    subtype = folio_field.split(".")[-1]
+    type_name = _ALT_TITLE_TYPE_NAMES[subtype]
+
+    type_id = None
+    for row in folio_client.alternative_title_types:
+        if row["name"] == type_name:
+            type_id = row["id"]
+            break
+
+    alt_titles = kwargs["record"].get("alternativeTitles", [])
+    for row in values:
+        title = row[0]
+        if row[1]:  # subtitle
+            title = f"{title} : {row[1]}"
+        if row[2]:  # partNumber
+            title = f"{title}. {row[2]}"
+        if row[3]:  # partName
+            title = f"{title}, {row[3]}"
+        alt_titles.append({"alternativeTitleTypeId": type_id, "alternativeTitle": title})
+
+    return "alternativeTitles", alt_titles
+
+
 def _default_transform(**kwargs) -> tuple:
     folio_field = kwargs["folio_field"]
     values = kwargs.get("values", [])
     logger.debug(f"field: {folio_field} values: {values} type: {type(values)}")
     return folio_field, values
+
+
+def _electronic_access(**kwargs) -> tuple:
+    values = kwargs["values"]
+    return "electronicAccess", [{"uri": row[0]} for row in values]
 
 
 def _editions(**kwargs) -> tuple:
@@ -198,6 +273,11 @@ def _physical_descriptions(**kwargs) -> tuple:
     return "physicalDescriptions", output
 
 
+def _publication_frequency(**kwargs) -> tuple:
+    values = kwargs["values"]
+    return "publicationFrequency", [row[0] for row in values]
+
+
 def _publication(**kwargs) -> tuple:
     values = kwargs["values"]
     publications = []
@@ -211,6 +291,14 @@ def _publication(**kwargs) -> tuple:
             publication["place"] = row[2]
         publications.append(publication)
     return "publication", publications
+
+
+def _series(**kwargs) -> tuple:
+    values = kwargs["values"]
+    series = kwargs["record"].get("series", [])
+    for row in values:
+        series.append({"value": row[0]})
+    return "series", series
 
 
 def _subjects(**kwargs) -> tuple:
@@ -267,9 +355,17 @@ def _user_folio_id(okapi_url: str, folio_user: str) -> str:
 
 
 transforms = {
+    "cataloged_date": _cataloged_date,
+    "classifications.ddc": _classifications,
+    "classifications.lcc": _classifications,
+    "classifications.nlm": _classifications,
+    "alternative_titles.abbreviated": _alternative_titles,
+    "alternative_titles.parallel": _alternative_titles,
+    "alternative_titles.variant": _alternative_titles,
     "contributor.Person": _non_primary_contributor,
     "contributor.primary.Person": _primary_contributor,
     "editions": _editions,
+    "electronic_access": _electronic_access,
     "editions.work": _editions,
     "identifiers.isbn": _identifiers,
     "identifiers.oclc": _identifiers,
@@ -284,6 +380,9 @@ transforms = {
     "notes": _notes,
     "physical_description": _physical_descriptions,
     "publication": _publication,
+    "publication_frequency": _publication_frequency,
+    "series.controlled": _series,
+    "series.uncontrolled": _series,
     "subjects": _subjects,
     "genre": _genre,
     "title": _title,
@@ -320,11 +419,18 @@ def _inventory_record(**kwargs: Any) -> dict[str, Any]:
     task_groups = ".".join(kwargs["task_groups_ids"])
     folio_client = kwargs["folio_client"]
 
+    status_id = None
+    for row in folio_client.instance_statuses:
+        if row["name"] == "Cataloged":
+            status_id = row["id"]
+            break
+
     record: dict[str, Any] = {
         "id": _folio_id(instance_uri, folio_client.okapi_url),
         "metadata": _create_update_metadata(**kwargs),
         "source": "BIBFRAME",
         "sourceUri": instance_uri,
+        "statusId": status_id,
     }
     instance_uuid = instance_uri.split("/")[-1]
 

--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -35,7 +35,7 @@ def _classifications(**kwargs) -> tuple:
     type_name = _CLASSIFICATION_TYPE_NAMES[subtype]
 
     type_id = None
-    for row in folio_client.classification_types:
+    for row in folio_client.class_types:
         if row["name"] == type_name:
             type_id = row["id"]
             break
@@ -65,7 +65,7 @@ def _alternative_titles(**kwargs) -> tuple:
     type_name = _ALT_TITLE_TYPE_NAMES[subtype]
 
     type_id = None
-    for row in folio_client.alternative_title_types:
+    for row in folio_client.alt_title_types:
         if row["name"] == type_name:
             type_id = row["id"]
             break
@@ -422,10 +422,9 @@ def _inventory_record(**kwargs: Any) -> dict[str, Any]:
     folio_client = kwargs["folio_client"]
 
     status_id = None
-    for row in folio_client.instance_statuses:
-        if row["name"] == "Cataloged":
-            status_id = row["id"]
-            break
+    instance_status = folio_client.folio_get("instance-statuses", "instanceStatuses", "name==Cataloged")
+    if instance_status:
+        status_id = instance_status[0]["id"]
 
     record: dict[str, Any] = {
         "id": _folio_id(instance_uri, folio_client.okapi_url),

--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -48,6 +48,21 @@ BF_TO_FOLIO_MAP = {
         "uri": "instance",
         "class": "bf:VariantTitle",
     },
+    "alternative_titles.abbreviated.work": {
+        "template": bf_work_map.alternative_title,
+        "uri": "work",
+        "class": "bf:AbbreviatedTitle",
+    },
+    "alternative_titles.parallel.work": {
+        "template": bf_work_map.alternative_title,
+        "uri": "work",
+        "class": "bf:ParallelTitle",
+    },
+    "alternative_titles.variant.work": {
+        "template": bf_work_map.alternative_title,
+        "uri": "work",
+        "class": "bf:VariantTitle",
+    },
     "contributor.Person": {
         "template": bf_work_map.contributor,
         "uri": "work",
@@ -113,6 +128,10 @@ BF_TO_FOLIO_MAP = {
         "template": bf_instance_map.publication_frequency,
         "uri": "instance",
     },
+    "publication_range": {
+        "template": bf_instance_map.publication_range,
+        "uri": "instance",
+    },
     "series.controlled": {
         "template": bf_work_map.series_controlled,
         "uri": "work",
@@ -123,6 +142,7 @@ BF_TO_FOLIO_MAP = {
     },
     "subjects": {"template": bf_work_map.subject, "uri": "work"},
     "genre": {"template": bf_work_map.genre, "uri": "work"},
+    "nature_of_content": {"template": bf_work_map.genre, "uri": "work"},
     "title": {
         "template": bf_instance_map.title,
         "uri": "instance",
@@ -148,7 +168,9 @@ def _retrieve_values(query_row: list | tuple) -> list:
                 output.append(str(field))
                 continue
             value = field.value
-            if isinstance(value, (datetime.date, datetime.datetime)):
+            if isinstance(value, datetime.datetime):
+                value = value.date().isoformat()
+            elif isinstance(value, datetime.date):
                 value = value.isoformat()
             output.append(value)
         else:

--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -13,6 +13,40 @@ logger = logging.getLogger(__name__)
 # identifiers, editions) must be ordered so the first writer populates the list before
 # subsequent entries append to it via record.get(..., []).
 BF_TO_FOLIO_MAP = {
+    "cataloged_date": {
+        "template": bf_instance_map.cataloged_date,
+        "uri": "instance",
+    },
+    "classifications.ddc": {
+        "template": bf_work_map.classification,
+        "uri": "work",
+        "class": "bf:ClassificationDdc",
+    },
+    "classifications.lcc": {
+        "template": bf_work_map.classification,
+        "uri": "work",
+        "class": "bf:ClassificationLcc",
+    },
+    "classifications.nlm": {
+        "template": bf_work_map.classification,
+        "uri": "work",
+        "class": "bf:ClassificationNlm",
+    },
+    "alternative_titles.abbreviated": {
+        "template": bf_instance_map.alternative_title,
+        "uri": "instance",
+        "class": "bf:AbbreviatedTitle",
+    },
+    "alternative_titles.parallel": {
+        "template": bf_instance_map.alternative_title,
+        "uri": "instance",
+        "class": "bf:ParallelTitle",
+    },
+    "alternative_titles.variant": {
+        "template": bf_instance_map.alternative_title,
+        "uri": "instance",
+        "class": "bf:VariantTitle",
+    },
     "contributor.Person": {
         "template": bf_work_map.contributor,
         "uri": "work",
@@ -24,6 +58,10 @@ BF_TO_FOLIO_MAP = {
         "class": "bf:Person",
     },
     "editions": {"template": bf_instance_map.editions, "uri": "instance"},
+    "electronic_access": {
+        "template": bf_instance_map.electronic_locator,
+        "uri": "instance",
+    },
     "editions.work": {"template": bf_work_map.editions, "uri": "work"},
     "instance_format": {
         "template": bf_instance_map.instance_format_id,
@@ -70,6 +108,18 @@ BF_TO_FOLIO_MAP = {
         "uri": "instance",
     },
     "publication": {"template": bf_instance_map.publication, "uri": "instance"},
+    "publication_frequency": {
+        "template": bf_instance_map.publication_frequency,
+        "uri": "instance",
+    },
+    "series.controlled": {
+        "template": bf_work_map.series_controlled,
+        "uri": "work",
+    },
+    "series.uncontrolled": {
+        "template": bf_work_map.series_uncontrolled,
+        "uri": "work",
+    },
     "subjects": {"template": bf_work_map.subject, "uri": "work"},
     "genre": {"template": bf_work_map.genre, "uri": "work"},
     "title": {

--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -1,5 +1,6 @@
 """Maps Sinopia RDF to FOLIO Records."""
 
+import datetime
 import logging
 
 import rdflib
@@ -146,7 +147,10 @@ def _retrieve_values(query_row: list | tuple) -> list:
             if isinstance(field, rdflib.URIRef):
                 output.append(str(field))
                 continue
-            output.append(field.value)
+            value = field.value
+            if isinstance(value, (datetime.date, datetime.datetime)):
+                value = value.isoformat()
+            output.append(value)
         else:
             output.append(None)  # type: ignore
     return output

--- a/ils_middleware/tasks/folio/mappings/bf_instance.py
+++ b/ils_middleware/tasks/folio/mappings/bf_instance.py
@@ -4,7 +4,7 @@ BF Instance with its associated BF Work.
 
 cataloged_date = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 
-SELECT ?date
+SELECT DISTINCT ?date
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:adminMetadata ?admin_metadata .
@@ -16,7 +16,7 @@ WHERE {{
 alternative_title = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?main_title ?subtitle ?part_number ?part_name
+SELECT DISTINCT ?main_title ?subtitle ?part_number ?part_name
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:title ?title .
@@ -31,7 +31,7 @@ WHERE {{
 editions = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT ?edition
+SELECT DISTINCT ?edition
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:editionStatement ?edition .
@@ -42,7 +42,7 @@ identifier = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?identifier
+SELECT DISTINCT ?identifier
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:identifiedBy ?ident_bnode .
@@ -55,7 +55,7 @@ instance_format_id = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?format_category ?format_term
+SELECT DISTINCT ?format_category ?format_term
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:media ?format_category_uri .
@@ -69,7 +69,7 @@ local_identifier = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?identifier
+SELECT DISTINCT ?identifier
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:identifiedBy ?ident_bnode .
@@ -88,7 +88,7 @@ WHERE {{
 
 electronic_locator = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 
-SELECT ?url
+SELECT DISTINCT ?url
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:electronicLocator ?url .
@@ -99,7 +99,7 @@ mode_of_issuance = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SElECT ?mode_of_issuance
+SElECT DISTINCT ?mode_of_issuance
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:issuance ?mode_of_issuance_uri .
@@ -111,7 +111,7 @@ note = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?note
+SELECT DISTINCT ?note
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:note ?note_bnode .
@@ -124,7 +124,7 @@ physical_description = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?extent ?dimensions
+SELECT DISTINCT ?extent ?dimensions
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:extent ?extent_bnode .
@@ -139,11 +139,23 @@ WHERE {{
 publication_frequency = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?frequency
+SELECT DISTINCT ?frequency
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:frequency ?freq_bnode .
+    FILTER (isBlank(?freq_bnode))
     ?freq_bnode rdfs:label ?frequency .
+}}
+"""
+
+publication_range = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+
+SELECT DISTINCT ?first_issue ?last_issue
+WHERE {{
+    <{bf_instance}> a bf:Instance .
+    OPTIONAL {{ <{bf_instance}> bf:firstIssue ?first_issue . }}
+    OPTIONAL {{ <{bf_instance}> bf:lastIssue ?last_issue . }}
+    FILTER (BOUND(?first_issue) || BOUND(?last_issue))
 }}
 """
 
@@ -151,7 +163,7 @@ publication = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?publisher ?date ?place
+SELECT DISTINCT ?publisher ?date ?place
 WHERE {{
    <{bf_instance}> a bf:Instance .
    <{bf_instance}> bf:provisionActivity ?activity .
@@ -176,7 +188,7 @@ title = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?main_title ?subtitle ?part_number ?part_name
+SELECT DISTINCT ?main_title ?subtitle ?part_number ?part_name
 WHERE {{
   <{bf_instance}> a bf:Instance .
   <{bf_instance}> bf:title ?title .

--- a/ils_middleware/tasks/folio/mappings/bf_instance.py
+++ b/ils_middleware/tasks/folio/mappings/bf_instance.py
@@ -2,6 +2,32 @@
 BF Instance with its associated BF Work.
 """
 
+cataloged_date = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+
+SELECT ?date
+WHERE {{
+    <{bf_instance}> a bf:Instance .
+    <{bf_instance}> bf:adminMetadata ?admin_metadata .
+    ?admin_metadata a bf:AdminMetadata .
+    ?admin_metadata bf:date ?date .
+}}
+"""
+
+alternative_title = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?main_title ?subtitle ?part_number ?part_name
+WHERE {{
+    <{bf_instance}> a bf:Instance .
+    <{bf_instance}> bf:title ?title .
+    ?title a {bf_class} .
+    ?title bf:mainTitle ?main_title .
+    OPTIONAL {{ ?title bf:subtitle ?subtitle . }}
+    OPTIONAL {{ ?title bf:partNumber ?part_number . }}
+    OPTIONAL {{ ?title bf:partName ?part_name . }}
+}}
+"""
+
 editions = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -60,6 +86,15 @@ WHERE {{
 }}
 """
 
+electronic_locator = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+
+SELECT ?url
+WHERE {{
+    <{bf_instance}> a bf:Instance .
+    <{bf_instance}> bf:electronicLocator ?url .
+}}
+"""
+
 mode_of_issuance = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -98,6 +133,17 @@ WHERE {{
     OPTIONAL {{
         <{bf_instance}> bf:dimensions ?dimensions .
     }}
+}}
+"""
+
+publication_frequency = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?frequency
+WHERE {{
+    <{bf_instance}> a bf:Instance .
+    <{bf_instance}> bf:frequency ?freq_bnode .
+    ?freq_bnode rdfs:label ?frequency .
 }}
 """
 

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -101,7 +101,9 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ?series_title
 WHERE {{
     <{bf_work}> a bf:Work .
-    <{bf_work}> bf:relation ?series .
+    <{bf_work}> bf:relation ?relation .
+    ?relation a bf:Relation .
+    ?relation bf:associatedResource ?series .
     ?series a bf:Series .
     ?series bf:title ?title_node .
     ?title_node bf:mainTitle ?series_title .

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -2,9 +2,23 @@
 BF Instance with its associated BF Work.
 """
 
+alternative_title = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+
+SELECT DISTINCT ?main_title ?subtitle ?part_number ?part_name
+WHERE {{
+    <{bf_work}> a bf:Work .
+    <{bf_work}> bf:title ?title .
+    ?title a {bf_class} .
+    ?title bf:mainTitle ?main_title .
+    OPTIONAL {{ ?title bf:subtitle ?subtitle . }}
+    OPTIONAL {{ ?title bf:partNumber ?part_number . }}
+    OPTIONAL {{ ?title bf:partName ?part_name . }}
+}}
+"""
+
 classification = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 
-SELECT ?class_number
+SELECT DISTINCT ?class_number
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:classification ?class_node .
@@ -18,7 +32,7 @@ PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?agent ?role
+SELECT DISTINCT ?agent ?role
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:contribution ?contrib_bnode .
@@ -36,7 +50,7 @@ editions = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?edition
+SELECT DISTINCT ?edition
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:editionStatement ?edition .
@@ -45,7 +59,7 @@ WHERE {{
 
 instance_type_id = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 
-SELECT ?instance_type_id
+SELECT DISTINCT ?instance_type_id
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:content ?instance_type .
@@ -55,7 +69,7 @@ WHERE {{
 
 language = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 
-SELECT ?language_uri ?language
+SELECT DISTINCT ?language_uri ?language
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:language ?language_uri .
@@ -68,7 +82,7 @@ PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?agent ?role
+SELECT DISTINCT ?agent ?role
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:contribution ?contrib_bnode .
@@ -84,7 +98,7 @@ WHERE {{
 series_controlled = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?series_title
+SELECT DISTINCT ?series_title
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:relation ?relation .
@@ -98,7 +112,7 @@ WHERE {{
 series_uncontrolled = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?series_title
+SELECT DISTINCT ?series_title
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:relation ?relation .
@@ -114,7 +128,7 @@ subject = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?subject
+SELECT DISTINCT ?subject
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:subject ?subject_node .
@@ -128,7 +142,7 @@ genre = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?genre
+SELECT DISTINCT ?genre
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:genreForm ?genre_node .

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -2,6 +2,17 @@
 BF Instance with its associated BF Work.
 """
 
+classification = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+
+SELECT ?class_number
+WHERE {{
+    <{bf_work}> a bf:Work .
+    <{bf_work}> bf:classification ?class_node .
+    ?class_node a {bf_class} .
+    ?class_node bf:classificationPortion ?class_number .
+}}
+"""
+
 contributor = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -67,6 +78,33 @@ WHERE {{
     ?contrib_bnode bf:agent ?agent_uri .
     ?agent_uri a {bf_class} .
     ?agent_uri rdfs:label ?agent .
+}}
+"""
+
+series_controlled = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?series_title
+WHERE {{
+    <{bf_work}> a bf:Work .
+    <{bf_work}> bf:relation ?relation .
+    ?relation a bf:Relation .
+    ?relation bf:associatedResource ?hub .
+    ?hub a bf:Hub .
+    ?hub rdfs:label ?series_title .
+}}
+"""
+
+series_uncontrolled = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?series_title
+WHERE {{
+    <{bf_work}> a bf:Work .
+    <{bf_work}> bf:relation ?series .
+    ?series a bf:Series .
+    ?series bf:title ?title_node .
+    ?title_node bf:mainTitle ?series_title .
 }}
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.13.0"
+version = "0.14.0"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]

--- a/tests/fixtures/bf.ttl
+++ b/tests/fixtures/bf.ttl
@@ -47,7 +47,9 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
 
 <https://api.stage.sinopia.io/resource/48e954be-4b9b-4589-b2a2-776551807d50> rdfs:label "Resource Description and Access"@eng .
 
-<https://api.stage.sinopia.io/resource/992c99e5-adde-4d63-afcd-3391128136fe> rdfs:label "Resource Description and Access"@eng .
+<https://api.stage.sinopia.io/resource/992c99e5-adde-4d63-afcd-3391128136fe> a bf:AdminMetadata ;
+    rdfs:label "Resource Description and Access"@eng ;
+    bf:date "2021-10-01" .
 
 <https://api.stage.sinopia.io/resource/b0319047-acd0-4f30-bd8b-98e6c1bac6b0> a bf:Instance ;
     rdfs:label "OCLC"@eng ;
@@ -153,4 +155,23 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
             bf:agent <https://api.stage.sinopia.io/resource/pub-agent-oup> ;
             bf:date "2021" ;
             bf:place <https://api.stage.sinopia.io/resource/pub-place-oxford> ] .
+
+<https://api.stage.sinopia.io/resource/b0319047-acd0-4f30-bd8b-98e6c1bac6b0> bf:frequency [ rdfs:label "annual" ] ;
+    bf:title [ a bf:VariantTitle ;
+            bf:mainTitle "Scrivere Islam"@ita ],
+        [ a bf:AbbreviatedTitle ;
+            bf:mainTitle "Islam writing"@eng ] .
+
+<https://api.stage.sinopia.io/resource/c96d8b55-e0ac-48a5-9a9b-b0684758c99e> bf:classification [ a bf:ClassificationDdc ;
+            bf:classificationPortion "297.09451" ],
+        [ a bf:ClassificationNlm ;
+            bf:classificationPortion "BP52" ] ;
+    bf:relation [ a bf:Relation ;
+            bf:associatedResource <https://api.stage.sinopia.io/resource/test-series-hub> ],
+        [ a bf:Series ;
+            bf:title [ a bf:Title ;
+                    bf:mainTitle "Italian studies series" ] ] .
+
+<https://api.stage.sinopia.io/resource/test-series-hub> a bf:Hub ;
+    rdfs:label "Diaspore" .
 

--- a/tests/fixtures/bf.ttl
+++ b/tests/fixtures/bf.ttl
@@ -168,9 +168,10 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
             bf:classificationPortion "BP52" ] ;
     bf:relation [ a bf:Relation ;
             bf:associatedResource <https://api.stage.sinopia.io/resource/test-series-hub> ],
-        [ a bf:Series ;
-            bf:title [ a bf:Title ;
-                    bf:mainTitle "Italian studies series" ] ] .
+        [ a bf:Relation ;
+            bf:associatedResource [ a bf:Series ;
+                    bf:title [ a bf:Title ;
+                            bf:mainTitle "Italian studies series" ] ] ] .
 
 <https://api.stage.sinopia.io/resource/test-series-hub> a bf:Hub ;
     rdfs:label "Diaspore" .

--- a/tests/fixtures/bf.ttl
+++ b/tests/fixtures/bf.ttl
@@ -156,7 +156,9 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
             bf:date "2021" ;
             bf:place <https://api.stage.sinopia.io/resource/pub-place-oxford> ] .
 
-<https://api.stage.sinopia.io/resource/b0319047-acd0-4f30-bd8b-98e6c1bac6b0> bf:frequency [ rdfs:label "annual" ] ;
+<https://api.stage.sinopia.io/resource/b0319047-acd0-4f30-bd8b-98e6c1bac6b0> bf:firstIssue "Vol. 1" ;
+    bf:lastIssue "Vol. 10" ;
+    bf:frequency [ a bf:Frequency ; rdfs:label "annual" ] ;
     bf:title [ a bf:VariantTitle ;
             bf:mainTitle "Scrivere Islam"@ita ],
         [ a bf:AbbreviatedTitle ;
@@ -166,6 +168,10 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
             bf:classificationPortion "297.09451" ],
         [ a bf:ClassificationNlm ;
             bf:classificationPortion "BP52" ] ;
+    bf:title [ a bf:VariantTitle ;
+            bf:mainTitle "Islam writing work variant"@eng ],
+        [ a bf:AbbreviatedTitle ;
+            bf:mainTitle "Islam wr."@eng ] ;
     bf:relation [ a bf:Relation ;
             bf:associatedResource <https://api.stage.sinopia.io/resource/test-series-hub> ],
         [ a bf:Relation ;

--- a/tests/tasks/folio/mappings/test_bf_instance.py
+++ b/tests/tasks/folio/mappings/test_bf_instance.py
@@ -98,3 +98,61 @@ def test_parallel_title(test_graph: rdflib.Graph):
 
     assert str(titles[0][0]).startswith("Writing about Islam")
     assert str(titles[0][1]).startswith("narrating a diaspora")
+
+
+@typing.no_type_check
+def test_cataloged_date(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.cataloged_date.format(bf_instance=uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("2021-10-01")
+
+
+@typing.no_type_check
+def test_alternative_title_variant(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.alternative_title.format(
+        bf_instance=uri, bf_class="bf:VariantTitle"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Scrivere Islam")
+
+
+@typing.no_type_check
+def test_alternative_title_abbreviated(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.alternative_title.format(
+        bf_instance=uri, bf_class="bf:AbbreviatedTitle"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Islam writing")
+
+
+@typing.no_type_check
+def test_alternative_title_parallel(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.alternative_title.format(
+        bf_instance=uri, bf_class="bf:ParallelTitle"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Writing about Islam")
+
+
+@typing.no_type_check
+def test_electronic_locator(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.electronic_locator.format(bf_instance=uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    urls = [str(row[0]) for row in results]
+    assert any(url.startswith("https://purl.stanford.edu/mf283yt5578") for url in urls)
+    assert any(
+        url.startswith("https://phaidra.cab.unipd.it/detail/o:445140") for url in urls
+    )
+
+
+@typing.no_type_check
+def test_publication_frequency(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.publication_frequency.format(bf_instance=uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("annual")

--- a/tests/tasks/folio/mappings/test_bf_instance.py
+++ b/tests/tasks/folio/mappings/test_bf_instance.py
@@ -156,3 +156,12 @@ def test_publication_frequency(test_graph: rdflib.Graph):
     results = [row for row in test_graph.query(sparql)]
 
     assert str(results[0][0]).startswith("annual")
+
+
+@typing.no_type_check
+def test_publication_range(test_graph: rdflib.Graph):
+    sparql = bf_instance_map.publication_range.format(bf_instance=uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]) == "Vol. 1"
+    assert str(results[0][1]) == "Vol. 10"

--- a/tests/tasks/folio/mappings/test_bf_work.py
+++ b/tests/tasks/folio/mappings/test_bf_work.py
@@ -76,3 +76,49 @@ def test_genre(test_graph: rdflib.Graph):
     genres = [row for row in test_graph.query(sparql)]
 
     assert str(genres[0][0]).startswith("Informational works")
+
+
+@typing.no_type_check
+def test_classification_lcc(test_graph: rdflib.Graph):
+    sparql = bf_work_map.classification.format(
+        bf_work=work_uri, bf_class="bf:ClassificationLcc"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("BP52.5")
+
+
+@typing.no_type_check
+def test_classification_ddc(test_graph: rdflib.Graph):
+    sparql = bf_work_map.classification.format(
+        bf_work=work_uri, bf_class="bf:ClassificationDdc"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("297.09451")
+
+
+@typing.no_type_check
+def test_classification_nlm(test_graph: rdflib.Graph):
+    sparql = bf_work_map.classification.format(
+        bf_work=work_uri, bf_class="bf:ClassificationNlm"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("BP52")
+
+
+@typing.no_type_check
+def test_series_controlled(test_graph: rdflib.Graph):
+    sparql = bf_work_map.series_controlled.format(bf_work=work_uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Diaspore")
+
+
+@typing.no_type_check
+def test_series_uncontrolled(test_graph: rdflib.Graph):
+    sparql = bf_work_map.series_uncontrolled.format(bf_work=work_uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Italian studies series")

--- a/tests/tasks/folio/mappings/test_bf_work.py
+++ b/tests/tasks/folio/mappings/test_bf_work.py
@@ -122,3 +122,23 @@ def test_series_uncontrolled(test_graph: rdflib.Graph):
     results = [row for row in test_graph.query(sparql)]
 
     assert str(results[0][0]).startswith("Italian studies series")
+
+
+@typing.no_type_check
+def test_alternative_title_variant_work(test_graph: rdflib.Graph):
+    sparql = bf_work_map.alternative_title.format(
+        bf_work=work_uri, bf_class="bf:VariantTitle"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Islam writing work variant")
+
+
+@typing.no_type_check
+def test_alternative_title_abbreviated_work(test_graph: rdflib.Graph):
+    sparql = bf_work_map.alternative_title.format(
+        bf_work=work_uri, bf_class="bf:AbbreviatedTitle"
+    )
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("Islam wr.")

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -92,12 +92,12 @@ class MockFolioClient(object):
             {"id": "d6488f88-1e74-40ce-81b5-b19a928ff5b7", "name": "Topical term"},
             {"id": "d6488f88-1e74-4674-9e7f-a294b9a6451d", "name": "Genre/form"},
         ]
-        self.alternative_title_types = [
+        self.alt_title_types = [
             {"id": "bba5b222-1cc8-4745-9a75-3f1d3b5c3a67", "name": "Abbreviated title"},
             {"id": "4bb300a4-04c9-414b-bfbc-9c032f74b7b2", "name": "Parallel title"},
             {"id": "35bbe7f2-1a49-11ed-861d-0242ac120002", "name": "Variant title"},
         ]
-        self.classification_types = [
+        self.class_types = [
             {"id": "ce176ace-a53e-4b4d-aa89-725ed7b2edac", "name": "LC"},
             {"id": "42471af9-7d25-4f3a-bf78-60d29dcf463b", "name": "Dewey"},
             {"id": "a7f4d03f-b0d8-496c-aebf-4e9cdb678200", "name": "NLM"},

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -13,8 +13,12 @@ from tasks import (
 
 import ils_middleware.tasks.folio.build as folio_build
 from ils_middleware.tasks.folio.build import (
+    _alternative_titles,
+    _cataloged_date,
+    _classifications,
     _default_transform,
     _editions,
+    _electronic_access,
     _genre,
     _identifiers,
     _instance_format_ids,
@@ -26,6 +30,8 @@ from ils_middleware.tasks.folio.build import (
     _notes,
     _physical_descriptions,
     _publication,
+    _publication_frequency,
+    _series,
     _subjects,
     _title,
     _user_folio_id,
@@ -85,6 +91,19 @@ class MockFolioClient(object):
         self.subject_types = [
             {"id": "d6488f88-1e74-40ce-81b5-b19a928ff5b7", "name": "Topical term"},
             {"id": "d6488f88-1e74-4674-9e7f-a294b9a6451d", "name": "Genre/form"},
+        ]
+        self.alternative_title_types = [
+            {"id": "bba5b222-1cc8-4745-9a75-3f1d3b5c3a67", "name": "Abbreviated title"},
+            {"id": "4bb300a4-04c9-414b-bfbc-9c032f74b7b2", "name": "Parallel title"},
+            {"id": "35bbe7f2-1a49-11ed-861d-0242ac120002", "name": "Variant title"},
+        ]
+        self.classification_types = [
+            {"id": "ce176ace-a53e-4b4d-aa89-725ed7b2edac", "name": "LC"},
+            {"id": "42471af9-7d25-4f3a-bf78-60d29dcf463b", "name": "Dewey"},
+            {"id": "a7f4d03f-b0d8-496c-aebf-4e9cdb678200", "name": "NLM"},
+        ]
+        self.instance_statuses = [
+            {"id": "9634a5ab-9228-4703-baf2-4d12ebc77d56", "name": "Cataloged"},
         ]
 
     def folio_get(self, *args, **kwargs):
@@ -440,3 +459,165 @@ def test_folio_uuid():
     user_uuid = _user_folio_id(okapi_uri, "dschully")
 
     assert user_uuid.startswith("5415dbd9-8f80-50a2-9d6c-b1c932a4a6a5")
+
+
+def test_cataloged_date():
+    result = _cataloged_date(values=[["2021-10-01"]])
+    assert result[0] == "catalogedDate"
+    assert result[1] == "2021-10-01"
+
+
+def test_publication_frequency():
+    result = _publication_frequency(values=[["annual"], ["monthly"]])
+    assert result[0] == "publicationFrequency"
+    assert result[1] == ["annual", "monthly"]
+
+
+def test_electronic_access():
+    result = _electronic_access(
+        values=[
+            ["https://purl.stanford.edu/mf283yt5578"],
+            ["https://phaidra.cab.unipd.it/detail/o:445140"],
+        ]
+    )
+    assert result[0] == "electronicAccess"
+    assert result[1][0] == {"uri": "https://purl.stanford.edu/mf283yt5578"}
+    assert result[1][1] == {"uri": "https://phaidra.cab.unipd.it/detail/o:445140"}
+
+
+def test_series():
+    field, series = _series(values=[["Italian studies series"]], record={})
+    assert field == "series"
+    assert series[0] == {"value": "Italian studies series"}
+
+
+def test_series_accumulates():
+    _, first_series = _series(values=[["Diaspore"]], record={})
+    _, merged = _series(
+        values=[["Italian studies series"]], record={"series": first_series}
+    )
+    assert len(merged) == 2
+    assert {"value": "Diaspore"} in merged
+    assert {"value": "Italian studies series"} in merged
+
+
+def test_classifications_lcc():
+    result = _classifications(
+        folio_field="classifications.lcc",
+        values=[["BP52.5"]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert result[0] == "classifications"
+    assert result[1][0]["classificationNumber"] == "BP52.5"
+    assert (
+        result[1][0]["classificationTypeId"] == "ce176ace-a53e-4b4d-aa89-725ed7b2edac"
+    )
+
+
+def test_classifications_ddc():
+    result = _classifications(
+        folio_field="classifications.ddc",
+        values=[["297.09451"]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert result[0] == "classifications"
+    assert result[1][0]["classificationNumber"] == "297.09451"
+    assert (
+        result[1][0]["classificationTypeId"] == "42471af9-7d25-4f3a-bf78-60d29dcf463b"
+    )
+
+
+def test_classifications_nlm():
+    result = _classifications(
+        folio_field="classifications.nlm",
+        values=[["BP52"]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert result[0] == "classifications"
+    assert result[1][0]["classificationNumber"] == "BP52"
+    assert (
+        result[1][0]["classificationTypeId"] == "a7f4d03f-b0d8-496c-aebf-4e9cdb678200"
+    )
+
+
+def test_classifications_accumulates():
+    _, first_class = _classifications(
+        folio_field="classifications.lcc",
+        values=[["BP52.5"]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    _, merged = _classifications(
+        folio_field="classifications.ddc",
+        values=[["297.09451"]],
+        folio_client=MockFolioClient(),
+        record={"classifications": first_class},
+    )
+    assert len(merged) == 2
+    assert merged[0]["classificationNumber"] == "BP52.5"
+    assert merged[1]["classificationNumber"] == "297.09451"
+
+
+def test_alternative_titles_parallel():
+    result = _alternative_titles(
+        folio_field="alternative_titles.parallel",
+        values=[["Writing about Islam", "narrating a diaspora", None, None]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert result[0] == "alternativeTitles"
+    assert (
+        result[1][0]["alternativeTitleTypeId"] == "4bb300a4-04c9-414b-bfbc-9c032f74b7b2"
+    )
+    assert (
+        result[1][0]["alternativeTitle"] == "Writing about Islam : narrating a diaspora"
+    )
+
+
+def test_alternative_titles_variant_no_subtitle():
+    result = _alternative_titles(
+        folio_field="alternative_titles.variant",
+        values=[["Scrivere Islam", None, None, None]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert result[0] == "alternativeTitles"
+    assert (
+        result[1][0]["alternativeTitleTypeId"] == "35bbe7f2-1a49-11ed-861d-0242ac120002"
+    )
+    assert result[1][0]["alternativeTitle"] == "Scrivere Islam"
+
+
+def test_alternative_titles_abbreviated():
+    result = _alternative_titles(
+        folio_field="alternative_titles.abbreviated",
+        values=[["Islam writing", None, None, None]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert result[0] == "alternativeTitles"
+    assert (
+        result[1][0]["alternativeTitleTypeId"] == "bba5b222-1cc8-4745-9a75-3f1d3b5c3a67"
+    )
+    assert result[1][0]["alternativeTitle"] == "Islam writing"
+
+
+def test_alternative_titles_accumulates():
+    _, first_titles = _alternative_titles(
+        folio_field="alternative_titles.parallel",
+        values=[["Writing about Islam", None, None, None]],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    _, merged = _alternative_titles(
+        folio_field="alternative_titles.variant",
+        values=[["Scrivere Islam", None, None, None]],
+        folio_client=MockFolioClient(),
+        record={"alternativeTitles": first_titles},
+    )
+    assert len(merged) == 2
+    assert merged[0]["alternativeTitle"] == "Writing about Islam"
+    assert merged[1]["alternativeTitle"] == "Scrivere Islam"

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -20,6 +20,7 @@ from ils_middleware.tasks.folio.build import (
     _editions,
     _electronic_access,
     _genre,
+    _nature_of_content,
     _identifiers,
     _instance_format_ids,
     _instance_type_id,
@@ -115,6 +116,12 @@ class MockFolioClient(object):
         if args[0].endswith("subject-types"):
             return [
                 {"name": "Genre/form", "id": "d6488f88-1e74-4674-9e7f-a294b9a6451d"}
+            ]
+        if args[0].endswith("nature-of-content-terms"):
+            return [
+                {"name": "journal", "id": "0abeee3d-8ad2-4b04-92ff-221b4fce1075"},
+                {"name": "proceedings", "id": "073f7f2f-9212-4395-b039-6f9825b11d54"},
+                {"name": "thesis", "id": "94f6d06a-61e0-47c1-bbcb-6186989e6040"},
             ]
         return get_response
 
@@ -441,6 +448,21 @@ def test_genre_merges_into_subjects():
     assert subjects[0] == {"value": "Mining engineering"}
     assert subjects[1]["value"] == "Science fiction"
     assert subjects[1]["typeId"] == "d6488f88-1e74-4674-9e7f-a294b9a6451d"
+
+
+def test_nature_of_content_matching():
+    field, term_ids = _nature_of_content(
+        values=[
+            ["Conference papers and proceedings"],
+            ["Electronic journals"],
+            ["Informational works"],
+        ],
+        folio_client=MockFolioClient(),
+    )
+    assert field == "natureOfContentTermIds"
+    assert "073f7f2f-9212-4395-b039-6f9825b11d54" in term_ids  # proceedings
+    assert "0abeee3d-8ad2-4b04-92ff-221b4fce1075" in term_ids  # journal
+    assert len(term_ids) == 2
 
 
 def test_title_transform_all():

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
## Why was this change made?
Fixes #130 
Adds missing FOLIO fields: publicationFrequency, alternativeTitles, series, classifications, electronicAccess, and catalogedDate.


## How was this change tested?
tests/fixtures/bf.ttl — new RDF fixture data for:
- bf:AdminMetadata type + bf:date "2021-10-01" on the existing admin metadata resource
- bf:frequency bnode with rdfs:label "annual" on the instance
- bf:VariantTitle and bf:AbbreviatedTitle title nodes on the instance
- bf:ClassificationDdc and bf:ClassificationNlm on the work
- bf:Hub resource + bf:Relation/bf:Series on the work for series tests

test_bf_instance.py — 6 new SPARQL tests: test_cataloged_date, test_alternative_title_parallel/variant/abbreviated, test_electronic_locator, test_publication_frequency

test_bf_work.py — 5 new SPARQL tests: test_classification_lcc/ddc/nlm, test_series_controlled, test_series_uncontrolled

test_build.py — new alternative_title_types, classification_types, instance_statuses on MockFolioClient, plus 14 new transform tests covering all 6 new functions including accumulation behavior.

Live mapping tests: https://folio-dev.stanford.edu/inventory/view?filters=source.BIBFRAME&sort=title

## Which documentation and/or configurations were updated?
BF_TO_FOLIO_MAP added: cataloged_date, electronic_access, classifications.lcc, classifications.nlm, classifications.ddc, series.uncontrolled, series.controlled, alternative_titles.variant, alternative_titles.parallel, alternative_titles.abbreviated, publication_frequency.



