### PR TITLE
Adds param to check viability of db connection

### DIFF
--- a/ils_middleware/tasks/bluecore.py
+++ b/ils_middleware/tasks/bluecore.py
@@ -148,7 +148,7 @@ def load_cbd_files(
 
     bc_url = os.environ.get("AIRFLOW_VAR_BLUECORE_URL", "https://bcld.info")
 
-    engine = create_engine(bluecore_db)
+    engine = create_engine(bluecore_db, pool_pre_ping=True)
     session_maker = sessionmaker(bind=engine)
 
     errors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.12.0"
+version = "0.13.0"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
## Why was this change made?
Running `archived_file_upload` DAG was failing due to dropped connections. The `pool_pre_ping` parameter checks if the current connection is available and if it isn't will create a new connection


## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
`pyproject.yaml` and `uv.lock`



