### PR TITLE
Deduplicate bf:contributors with multiple text nodes

### DIFF
--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -42,7 +42,9 @@ WHERE {{
     ?role_uri rdfs:label ?role .
     ?contrib_bnode bf:agent ?agent_uri .
     ?agent_uri a {bf_class} .
-    ?agent_uri rdfs:label ?agent .
+    OPTIONAL {{ ?agent_uri rdfs:label ?agent_tagged . FILTER(lang(?agent_tagged) != "") }}
+    OPTIONAL {{ ?agent_uri rdfs:label ?agent_plain . FILTER(lang(?agent_plain) = "") }}
+    BIND(COALESCE(?agent_tagged, ?agent_plain) AS ?agent)
 }}
 """
 
@@ -91,7 +93,9 @@ WHERE {{
     ?role_uri rdfs:label ?role .
     ?contrib_bnode bf:agent ?agent_uri .
     ?agent_uri a {bf_class} .
-    ?agent_uri rdfs:label ?agent .
+    OPTIONAL {{ ?agent_uri rdfs:label ?agent_tagged . FILTER(lang(?agent_tagged) != "") }}
+    OPTIONAL {{ ?agent_uri rdfs:label ?agent_plain . FILTER(lang(?agent_plain) = "") }}
+    BIND(COALESCE(?agent_tagged, ?agent_plain) AS ?agent)
 }}
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-workflows"
-version = "0.14.1"
+version = "0.14.2"
 description = "Blue Core Workflows using Apache Airflow"
 readme = "README.md"
 authors = [{ name = "Jeremy Nelson", email = "jpnelson@stanford.edu"}]

--- a/tests/fixtures/bf.ttl
+++ b/tests/fixtures/bf.ttl
@@ -7,7 +7,8 @@
 <http://id.loc.gov/authorities/genreForms/gf2014026113> rdfs:label "Informational works@en"@eng .
 
 <http://id.loc.gov/authorities/names/n2012041708> a bf:Person ;
-    rdfs:label "Brioni, Simone"@eng .
+    rdfs:label "Brioni, Simone"@eng,
+        "Brioni, Simone" .
 
 <http://id.loc.gov/authorities/names/n79018142> rdfs:label "Venice (Italy)"@eng .
 

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-workflows"
-version = "0.14.0"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },
@@ -916,8 +916,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -1680,10 +1680,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [


### PR DESCRIPTION
## Why was this change made?
@kallimathios found a bug where contributors were being duplicated in the mapping from works to folio instances if there were multiple text nodes, for example:
```
"rdfs:label": [
        {
          "@language": "en",
          "@value": "Mancia, Mauro"
        },
        "Mancia, Mauro"
      ]
```


## How was this change tested?
Adding similar rdf pattern to tests/fixtures/bf.ttl


## Which documentation and/or configurations were updated?
N/A


