### PR TITLE
Add bf:summary to FOLIO Summary note

### DIFF
--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -262,6 +262,23 @@ def _notes(**kwargs) -> tuple:
     return "notes", notes
 
 
+def _summary_notes(**kwargs) -> tuple:
+    values = kwargs["values"]
+    folio_client = kwargs["folio_client"]
+    note_id = None
+    for row in folio_client.instance_note_types:
+        if row["name"].startswith("Summary"):
+            note_id = row["id"]
+            break
+    notes = kwargs["record"].get("notes", [])
+    for row in values:
+        notes.append(
+            {"instanceNoteTypeId": note_id, "note": row[0], "staffOnly": False}
+        )
+
+    return "notes", notes
+
+
 def _physical_descriptions(**kwargs) -> tuple:
     values = kwargs["values"]
     output = []
@@ -421,6 +438,7 @@ transforms = {
     "language": _language,
     "modeOfIssuanceId": _mode_of_issuance_id,
     "notes": _notes,
+    "notes.summary": _summary_notes,
     "physical_description": _physical_descriptions,
     "publication": _publication,
     "publication_frequency": _publication_frequency,

--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -119,6 +119,7 @@ BF_TO_FOLIO_MAP = {
         "uri": "instance",
     },
     "notes": {"template": bf_instance_map.note, "uri": "instance"},
+    "notes.summary": {"template": bf_work_map.summary, "uri": "work"},
     "physical_description": {
         "template": bf_instance_map.physical_description,
         "uri": "instance",

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -113,6 +113,18 @@ WHERE {{
 }}
 """
 
+summary = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?summary
+WHERE {{
+    <{bf_work}> a bf:Work .
+    <{bf_work}> bf:summary ?summary_bnode .
+    ?summary_bnode a bf:Summary .
+    ?summary_bnode rdfs:label ?summary .
+}}
+"""
+
 series_uncontrolled = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 

--- a/tests/tasks/folio/mappings/test_bf_work.py
+++ b/tests/tasks/folio/mappings/test_bf_work.py
@@ -135,6 +135,14 @@ def test_alternative_title_variant_work(test_graph: rdflib.Graph):
 
 
 @typing.no_type_check
+def test_summary(test_graph: rdflib.Graph):
+    sparql = bf_work_map.summary.format(bf_work=work_uri)
+    results = [row[0] for row in test_graph.query(sparql)]
+
+    assert str(results[0]).startswith('"Scrivere di Islam')
+
+
+@typing.no_type_check
 def test_alternative_title_abbreviated_work(test_graph: rdflib.Graph):
     sparql = bf_work_map.alternative_title.format(
         bf_work=work_uri, bf_class="bf:AbbreviatedTitle"

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -29,6 +29,7 @@ from ils_middleware.tasks.folio.build import (
     _mode_of_issuance_id,
     _non_primary_contributor,
     _notes,
+    _summary_notes,
     _physical_descriptions,
     _publication,
     _publication_frequency,
@@ -88,6 +89,7 @@ class MockFolioClient(object):
         ]
         self.instance_note_types = [
             {"id": "6a2533a7-4de2-4e64-8466-074c2fa9308c", "name": "General note"},
+            {"id": "d51c86e5-9a72-4a5e-9b6c-3f1f1e4f2e3e", "name": "Summary"},
         ]
         self.subject_types = [
             {"id": "d6488f88-1e74-40ce-81b5-b19a928ff5b7", "name": "Topical term"},
@@ -366,6 +368,36 @@ def test_notes():  # noqa: F811
     )
     assert (notes[1][0]["note"]).startswith("A great note")
     assert notes[1][0]["staffOnly"] is False
+
+
+def test_summary_notes():  # noqa: F811
+    notes = _summary_notes(
+        values=[["A great summary"]], folio_client=MockFolioClient(), record={}
+    )
+    assert (notes[0]).startswith("notes")
+    assert (notes[1][0]["instanceNoteTypeId"]).startswith(
+        "d51c86e5-9a72-4a5e-9b6c-3f1f1e4f2e3e"
+    )
+    assert (notes[1][0]["note"]).startswith("A great summary")
+    assert notes[1][0]["staffOnly"] is False
+
+
+def test_summary_notes_appends_to_existing_notes():  # noqa: F811
+    existing_notes = [
+        {
+            "instanceNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c",
+            "note": "A general note",
+            "staffOnly": False,
+        }
+    ]
+    notes = _summary_notes(
+        values=[["A great summary"]],
+        folio_client=MockFolioClient(),
+        record={"notes": existing_notes},
+    )
+    assert len(notes[1]) == 2
+    assert notes[1][0]["note"].startswith("A general note")
+    assert notes[1][1]["note"].startswith("A great summary")
 
 
 def test_physical_descriptions():


### PR DESCRIPTION
## Why was this change made?
Add missing export of bf:summary --> note w/ instanceNoteTypeId == Summary.


## How was this change tested?
modified:   tests/tasks/folio/mappings/test_bf_work.py
modified:   tests/tasks/folio/test_build.py

https://folio-test.stanford.edu/inventory/view/a1b07606-e962-5571-ad37-74e9fd09a78e?filters=source.BIBFRAME&sort=title


## Which documentation and/or configurations were updated?
N/A


