### PR TITLE
Map id.loc note types to folio note types

### DIFF
--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -244,17 +244,79 @@ def _mode_of_issuance_id(**kwargs) -> tuple:
     return "modeOfIssuanceId", mode_id
 
 
+# Maps a http://id.loc.gov/vocabulary/mnotetype/ code (the LC vocabulary used to
+# type bf:Note resources, which corresponds 1:1 with MARC 5XX note fields) to the
+# name of the matching FOLIO instance note type. Codes with no clear FOLIO
+# equivalent (e.g. structured/fixed-field data like "metaentry" or "number", or
+# ambiguous multi-field codes like "related") are left unmapped and fall back to
+# "General note".
+MNOTETYPE_CODE_TO_FOLIO_NOTE_TYPE = {
+    "action": "Action note",
+    "addphys": "Additional Physical Form Available note",
+    "adminhist": "Biographical or Historical Data",
+    "award": "Awards note",
+    "biblio": "Bibliography note",
+    "binding": "Binding Information note",
+    "biogdata": "Biographical or Historical Data",
+    "citeas": "Preferred Citation of Described Materials note",
+    "computer": "Type of computer file or data note",
+    "credits": "Creation / Production Credits note",
+    "descsource": "Source of Description note",
+    "doc": "Information About Documentation note",
+    "exhibit": "Exhibitions note",
+    "finding": "Cumulative Index / Finding Aides notes",
+    "fundinfo": "Funding Information Note",
+    "geocov": "Geographic Coverage note",
+    "index": "Cumulative Index / Finding Aides notes",
+    "issuance": "Numbering peculiarities note",
+    "issuing": "Issuing Body note",
+    "lang": "Language note",
+    "loc": "Citation / References note",
+    "orig": "Original Version note",
+    "participants": "Participant or Performer note",
+    "refcitation": "Citation / References note",
+    "relnote": "Linking Entry Complexity note",
+    "report": "Type of report and period covered note",
+    "repro": "Reproduction note",
+    "scale": "Cartographic Mathematical Data",
+    "source": "General note",
+    "suppl": "Supplement note",
+    "with": "With note",
+}
+
+
+def _note_type_id_by_name(folio_client, name: str) -> Any:
+    for row in folio_client.instance_note_types:
+        if row["name"] == name:
+            return row["id"]
+    return None
+
+
+def _general_note_type_id(folio_client) -> Any:
+    for row in folio_client.instance_note_types:
+        if row["name"].startswith("General note"):
+            return row["id"]
+    return None
+
+
+def _note_type_id_for_row(folio_client, note_type_uri) -> Any:
+    if note_type_uri:
+        code = str(note_type_uri).rstrip("/").split("/")[-1]
+        name = MNOTETYPE_CODE_TO_FOLIO_NOTE_TYPE.get(code)
+        if name:
+            note_id = _note_type_id_by_name(folio_client, name)
+            if note_id:
+                return note_id
+    return _general_note_type_id(folio_client)
+
+
 def _notes(**kwargs) -> tuple:
     values = kwargs["values"]
     folio_client = kwargs["folio_client"]
-    note_id = None
-    # For now assign every note as a FOLIO "General note"
-    for row in folio_client.instance_note_types:
-        if row["name"].startswith("General note"):
-            note_id = row["id"]
-            break
-    notes = []
+    notes = kwargs["record"].get("notes", [])
     for row in values:
+        note_type_uri = row[1] if len(row) > 1 else None
+        note_id = _note_type_id_for_row(folio_client, note_type_uri)
         notes.append(
             {"instanceNoteTypeId": note_id, "note": row[0], "staffOnly": False}
         )
@@ -438,6 +500,7 @@ transforms = {
     "language": _language,
     "modeOfIssuanceId": _mode_of_issuance_id,
     "notes": _notes,
+    "notes.work": _notes,
     "notes.summary": _summary_notes,
     "physical_description": _physical_descriptions,
     "publication": _publication,

--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -119,6 +119,7 @@ BF_TO_FOLIO_MAP = {
         "uri": "instance",
     },
     "notes": {"template": bf_instance_map.note, "uri": "instance"},
+    "notes.work": {"template": bf_work_map.note, "uri": "work"},
     "notes.summary": {"template": bf_work_map.summary, "uri": "work"},
     "physical_description": {
         "template": bf_instance_map.physical_description,

--- a/ils_middleware/tasks/folio/mappings/bf_instance.py
+++ b/ils_middleware/tasks/folio/mappings/bf_instance.py
@@ -111,12 +111,16 @@ note = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT DISTINCT ?note
+SELECT DISTINCT ?note ?note_type
 WHERE {{
     <{bf_instance}> a bf:Instance .
     <{bf_instance}> bf:note ?note_bnode .
     ?note_bnode a bf:Note .
     ?note_bnode rdfs:label ?note .
+    OPTIONAL {{
+        ?note_bnode a ?note_type .
+        FILTER(STRSTARTS(STR(?note_type), "http://id.loc.gov/vocabulary/mnotetype/"))
+    }}
 }}
 """
 

--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -125,6 +125,22 @@ WHERE {{
 }}
 """
 
+note = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?note ?note_type
+WHERE {{
+    <{bf_work}> a bf:Work .
+    <{bf_work}> bf:note ?note_bnode .
+    ?note_bnode a bf:Note .
+    ?note_bnode rdfs:label ?note .
+    OPTIONAL {{
+        ?note_bnode a ?note_type .
+        FILTER(STRSTARTS(STR(?note_type), "http://id.loc.gov/vocabulary/mnotetype/"))
+    }}
+}}
+"""
+
 series_uncontrolled = """PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 

--- a/tests/fixtures/bf.ttl
+++ b/tests/fixtures/bf.ttl
@@ -80,7 +80,7 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
     bf:instanceOf <https://api.stage.sinopia.io/resource/c96d8b55-e0ac-48a5-9a9b-b0684758c99e> ;
     bf:issuance <http://id.loc.gov/vocabulary/issuance/mono> ;
     bf:media <http://id.loc.gov/vocabulary/mediaTypes/c> ;
-    bf:note [ a bf:Note ;
+    bf:note [ a bf:Note, <http://id.loc.gov/vocabulary/mnotetype/biblio> ;
             rdfs:label "Includes bibliographical references (page 117-128)"@eng ],
         [ a bf:Note ;
             rdfs:label "Description based on online resource (Stanford Digital Repository, viewed October 1, 2021)"@eng ] ;
@@ -123,6 +123,8 @@ bf:Work rdfs:label "http://id.loc.gov/ontologies/bibframe/Work" .
     bf:language <http://id.loc.gov/vocabulary/languages/ita> ;
     bf:notation [ a bf:Script ;
             rdfs:label "Latin"@eng ] ;
+    bf:note [ a bf:Note, <http://id.loc.gov/vocabulary/mnotetype/lang> ;
+            rdfs:label "In Italian."@eng ] ;
     bf:originDate "2020"@eng ;
     bf:originPlace <http://id.loc.gov/authorities/names/n79021783> ;
     bf:subject <http://id.loc.gov/authorities/subjects/sh2005004457>,

--- a/tests/tasks/folio/mappings/test_bf_instance.py
+++ b/tests/tasks/folio/mappings/test_bf_instance.py
@@ -47,10 +47,23 @@ def test_mode_of_issuance(test_graph: rdflib.Graph):
 @typing.no_type_check
 def test_note(test_graph: rdflib.Graph):
     sparql = bf_instance_map.note.format(bf_instance=uri)
-    notes = [row[0] for row in test_graph.query(sparql)]
+    results = [row for row in test_graph.query(sparql)]
+    notes = [row[0] for row in results]
+    note_types = {str(row[0]): row[1] for row in results}
 
     assert len(str(notes[0])) == 50
     assert len(str(notes[1])) == 90
+
+    assert str(
+        note_types["Includes bibliographical references (page 117-128)"]
+    ).startswith("http://id.loc.gov/vocabulary/mnotetype/biblio")
+    assert (
+        note_types[
+            "Description based on online resource (Stanford Digital Repository, "
+            "viewed October 1, 2021)"
+        ]
+        is None
+    )
 
 
 @typing.no_type_check

--- a/tests/tasks/folio/mappings/test_bf_work.py
+++ b/tests/tasks/folio/mappings/test_bf_work.py
@@ -143,6 +143,15 @@ def test_summary(test_graph: rdflib.Graph):
 
 
 @typing.no_type_check
+def test_note(test_graph: rdflib.Graph):
+    sparql = bf_work_map.note.format(bf_work=work_uri)
+    results = [row for row in test_graph.query(sparql)]
+
+    assert str(results[0][0]).startswith("In Italian.")
+    assert str(results[0][1]).startswith("http://id.loc.gov/vocabulary/mnotetype/lang")
+
+
+@typing.no_type_check
 def test_alternative_title_abbreviated_work(test_graph: rdflib.Graph):
     sparql = bf_work_map.alternative_title.format(
         bf_work=work_uri, bf_class="bf:AbbreviatedTitle"

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -90,6 +90,8 @@ class MockFolioClient(object):
         self.instance_note_types = [
             {"id": "6a2533a7-4de2-4e64-8466-074c2fa9308c", "name": "General note"},
             {"id": "d51c86e5-9a72-4a5e-9b6c-3f1f1e4f2e3e", "name": "Summary"},
+            {"id": "86b6e817-e1bc-42fb-bab0-70e7547de6c1", "name": "Bibliography note"},
+            {"id": "7356cde5-ec6b-4961-9cb0-961c48a37af4", "name": "Language note"},
         ]
         self.subject_types = [
             {"id": "d6488f88-1e74-40ce-81b5-b19a928ff5b7", "name": "Topical term"},
@@ -361,13 +363,69 @@ def test_mode_of_issuance_id():
 
 
 def test_notes():  # noqa: F811
-    notes = _notes(values=[["A great note"]], folio_client=MockFolioClient())
+    notes = _notes(
+        values=[["A great note"]], folio_client=MockFolioClient(), record={}
+    )
     assert (notes[0]).startswith("notes")
     assert (notes[1][0]["instanceNoteTypeId"]).startswith(
         "6a2533a7-4de2-4e64-8466-074c2fa9308c"
     )
     assert (notes[1][0]["note"]).startswith("A great note")
     assert notes[1][0]["staffOnly"] is False
+
+
+def test_notes_maps_mnotetype_to_folio_note_type():  # noqa: F811
+    notes = _notes(
+        values=[
+            [
+                "Includes bibliographical references",
+                "http://id.loc.gov/vocabulary/mnotetype/biblio",
+            ],
+            ["In Italian.", "http://id.loc.gov/vocabulary/mnotetype/lang"],
+        ],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert (notes[1][0]["instanceNoteTypeId"]).startswith(
+        "86b6e817-e1bc-42fb-bab0-70e7547de6c1"
+    )
+    assert (notes[1][1]["instanceNoteTypeId"]).startswith(
+        "7356cde5-ec6b-4961-9cb0-961c48a37af4"
+    )
+
+
+def test_notes_falls_back_to_general_note_for_unmapped_type():  # noqa: F811
+    notes = _notes(
+        values=[
+            [
+                "A note with an unmapped type",
+                "http://id.loc.gov/vocabulary/mnotetype/metaentry",
+            ]
+        ],
+        folio_client=MockFolioClient(),
+        record={},
+    )
+    assert (notes[1][0]["instanceNoteTypeId"]).startswith(
+        "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+    )
+
+
+def test_notes_appends_to_existing_notes():  # noqa: F811
+    existing_notes = [
+        {
+            "instanceNoteTypeId": "d51c86e5-9a72-4a5e-9b6c-3f1f1e4f2e3e",
+            "note": "A great summary",
+            "staffOnly": False,
+        }
+    ]
+    notes = _notes(
+        values=[["A great note"]],
+        folio_client=MockFolioClient(),
+        record={"notes": existing_notes},
+    )
+    assert len(notes[1]) == 2
+    assert notes[1][0]["note"].startswith("A great summary")
+    assert notes[1][1]["note"].startswith("A great note")
 
 
 def test_summary_notes():  # noqa: F811

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -363,9 +363,7 @@ def test_mode_of_issuance_id():
 
 
 def test_notes():  # noqa: F811
-    notes = _notes(
-        values=[["A great note"]], folio_client=MockFolioClient(), record={}
-    )
+    notes = _notes(values=[["A great note"]], folio_client=MockFolioClient(), record={})
     assert (notes[0]).startswith("notes")
     assert (notes[1][0]["instanceNoteTypeId"]).startswith(
         "6a2533a7-4de2-4e64-8466-074c2fa9308c"


### PR DESCRIPTION
## Why was this change made?
We are already mapping bf:summary to the folio note type for summary. Adding a static config map we can map all of the bf:note types to folio note types.


## How was this change tested?
modified:   tests/tasks/folio/mappings/test_bf_instance.py
modified:   tests/tasks/folio/mappings/test_bf_work.py
modified:   tests/tasks/folio/test_build.py

https://folio-test.stanford.edu/inventory/view/a1b07606-e962-5571-ad37-74e9fd09a78e?filters=source.BIBFRAME&sort=title


## Which documentation and/or configurations were updated?
Added static config map:
```
MNOTETYPE_CODE_TO_FOLIO_NOTE_TYPE = {
    "action": "Action note",
    "addphys": "Additional Physical Form Available note",
    "adminhist": "Biographical or Historical Data",
    "award": "Awards note",
    "biblio": "Bibliography note",
    "binding": "Binding Information note",
    "biogdata": "Biographical or Historical Data",
    "citeas": "Preferred Citation of Described Materials note",
    "computer": "Type of computer file or data note",
    "credits": "Creation / Production Credits note",
    "descsource": "Source of Description note",
    "doc": "Information About Documentation note",
    "exhibit": "Exhibitions note",
    "finding": "Cumulative Index / Finding Aides notes",
    "fundinfo": "Funding Information Note",
    "geocov": "Geographic Coverage note",
    "index": "Cumulative Index / Finding Aides notes",
    "issuance": "Numbering peculiarities note",
    "issuing": "Issuing Body note",
    "lang": "Language note",
    "loc": "Citation / References note",
    "orig": "Original Version note",
    "participants": "Participant or Performer note",
    "refcitation": "Citation / References note",
    "relnote": "Linking Entry Complexity note",
    "report": "Type of report and period covered note",
    "repro": "Reproduction note",
    "scale": "Cartographic Mathematical Data",
    "source": "General note",
    "suppl": "Supplement note",
    "with": "With note",
}
```



