### PR TITLE
Re-lock after version bump in weekly dependency updates

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -61,6 +61,10 @@ jobs:
           sed -i "s/^version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"$NEW_VERSION\"/" pyproject.toml
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Sync lockfile with bumped version
+        if: steps.check_changes.outputs.changed == 'true'
+        run: uv lock
+
       - name: Create Pull Request
         id: create_pr
         if: steps.check_changes.outputs.changed == 'true' && success()


### PR DESCRIPTION
## Why was this change made?

The workflow ran `uv lock --upgrade` before bumping the patch version in
pyproject.toml, so uv.lock kept the pre-bump project version for its own
package entry. Add a `uv lock` step after the bump to keep pyproject.toml
and uv.lock in sync.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## How was this change tested?

Need to wait for this to merge, and for our next dependency updates to run.

## Which documentation and/or configurations were updated?

n/a




