### PR TITLE
Cache and reuse SQLAlchemy engine per worker process

### DIFF
--- a/ils_middleware/tasks/bluecore.py
+++ b/ils_middleware/tasks/bluecore.py
@@ -28,11 +28,12 @@ if not logger.handlers:
 
 
 # Pool sizing per engine (i.e. per Celery worker child process). The load tasks
-# save graphs sequentially, so a single connection is enough; overflow gives a
-# little slack. Keep this small: with the default Airflow worker_concurrency of
-# 16, the worst-case bluecore connection count is
-# 16 * (POOL_SIZE + MAX_OVERFLOW), and it shares Postgres max_connections (100)
-# with the Airflow metadata DB and Keycloak.
+# save graphs sequentially, so a single pooled connection is enough; overflow
+# gives a little slack. Keep this small: the worst-case bluecore connection
+# count from a fully-busy worker is worker_concurrency * (POOL_SIZE +
+# MAX_OVERFLOW), and that shares the database server's connection budget with
+# Airflow, Keycloak, and any other clients on the same (often shared/external)
+# Postgres. Bounding it explicitly keeps this workflow's footprint predictable.
 POOL_SIZE = int(os.environ.get("BLUECORE_DB_POOL_SIZE", "1"))
 MAX_OVERFLOW = int(os.environ.get("BLUECORE_DB_MAX_OVERFLOW", "2"))
 # Recycle connections older than this (seconds) so we don't hand out a

--- a/ils_middleware/tasks/bluecore.py
+++ b/ils_middleware/tasks/bluecore.py
@@ -9,6 +9,7 @@ import zipfile
 import rdflib
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 from bluecore_models.bluecore_graph import save_graph
@@ -24,6 +25,41 @@ logging.getLogger("bluecore_models").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
 if not logger.handlers:
     logging.basicConfig(level=logging.INFO)
+
+
+# Pool sizing per engine (i.e. per Celery worker child process). The load tasks
+# save graphs sequentially, so a single connection is enough; overflow gives a
+# little slack. Keep this small: with the default Airflow worker_concurrency of
+# 16, the worst-case bluecore connection count is
+# 16 * (POOL_SIZE + MAX_OVERFLOW), and it shares Postgres max_connections (100)
+# with the Airflow metadata DB and Keycloak.
+POOL_SIZE = int(os.environ.get("BLUECORE_DB_POOL_SIZE", "1"))
+MAX_OVERFLOW = int(os.environ.get("BLUECORE_DB_MAX_OVERFLOW", "2"))
+# Recycle connections older than this (seconds) so we don't hand out a
+# connection Postgres has already closed server-side.
+POOL_RECYCLE = int(os.environ.get("BLUECORE_DB_POOL_RECYCLE", "1800"))
+
+# Engines are cached per database URL and reused across task invocations within
+# a worker child process, rather than created (and their pools leaked) per task.
+# The cache is populated lazily on first use *inside* each forked child, so no
+# pooled connection is ever shared across processes.
+_engines: dict[str, Engine] = {}
+
+
+def get_engine(bluecore_db: str) -> Engine:
+    """Return a process-local, pooled Engine for the given database URL,
+    creating and caching it on first use."""
+    engine = _engines.get(bluecore_db)
+    if engine is None:
+        engine = create_engine(
+            bluecore_db,
+            pool_pre_ping=True,
+            pool_recycle=POOL_RECYCLE,
+            pool_size=POOL_SIZE,
+            max_overflow=MAX_OVERFLOW,
+        )
+        _engines[bluecore_db] = engine
+    return engine
 
 
 def batch_archived_files(
@@ -115,8 +151,8 @@ def load(file_path: str, user_uid: str, bluecore_db: str):
     except Exception as e:
         logger.error("Failed to set CURRENT_USER_ID: %s", e)
 
-    # create the database session maker
-    engine = create_engine(bluecore_db)
+    # create the database session maker from the cached, process-local engine
+    engine = get_engine(bluecore_db)
     session_maker = sessionmaker(bind=engine)
 
     # parse the RDF into a graph
@@ -148,7 +184,7 @@ def load_cbd_files(
 
     bc_url = os.environ.get("AIRFLOW_VAR_BLUECORE_URL", "https://bcld.info")
 
-    engine = create_engine(bluecore_db, pool_pre_ping=True)
+    engine = get_engine(bluecore_db)
     session_maker = sessionmaker(bind=engine)
 
     errors = []

--- a/tests/tasks/test_bluecore.py
+++ b/tests/tasks/test_bluecore.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import OperationalError
 
+from ils_middleware.tasks import bluecore
 from ils_middleware.tasks.bluecore import (
     batch_archived_files,
     delete_upload,
@@ -14,6 +15,15 @@ from ils_middleware.tasks.bluecore import (
     load_cbd_files,
     zip_to_tar_gz,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_engine_cache():
+    """Engines are cached per DB URL at module scope; reset between tests so a
+    mocked engine from one test can't leak into the next."""
+    bluecore._engines.clear()
+    yield
+    bluecore._engines.clear()
 
 
 def test_batch_archived_files_no_file():
@@ -90,6 +100,22 @@ def test_get_bluecore_db(mock_postgres_hook):
     db_string = get_bluecore_db()
 
     assert db_string.startswith("postgresql://bluecore_admin")
+
+
+def test_get_engine_caches_per_url(mocker):
+    create_engine_mock = mocker.patch(
+        "ils_middleware.tasks.bluecore.create_engine",
+        side_effect=lambda url, **kwargs: mocker.MagicMock(name=url),
+    )
+
+    first = bluecore.get_engine("postgresql://host/db_a")
+    again = bluecore.get_engine("postgresql://host/db_a")
+    other = bluecore.get_engine("postgresql://host/db_b")
+
+    # same URL reuses one engine, a different URL gets its own
+    assert first is again
+    assert first is not other
+    assert create_engine_mock.call_count == 2
 
 
 def _build_cbd_archive(tmp_path):


### PR DESCRIPTION
## Summary

Switches the Blue Core load tasks (`load`, `load_cbd_files`) from calling
`create_engine()` on **every task invocation** to a **process-local cached engine
with a small, bounded connection pool** — the idiomatic SQLAlchemy pattern.

`get_engine(bluecore_db)` lazily creates one `Engine` per database URL and caches
it in a module-level dict, reused across all tasks a Celery worker child runs. The
cache is populated on first use *inside* each forked child, so no pooled connection
is ever shared across processes. Pool size is bounded and env-tunable
(`BLUECORE_DB_POOL_SIZE=1`, `BLUECORE_DB_MAX_OVERFLOW=2`, `BLUECORE_DB_POOL_RECYCLE=1800`),
with `pool_pre_ping` to guard against server-closed connections.

## Why (honest framing)

Adopted as **good practice / robustness**, not a proven fix for the production
connection exhaustion:

- Per-task `create_engine()` is a SQLAlchemy anti-pattern: each call builds a new
  `QueuePool` (default capacity 15) reclaimed only when the abandoned engine is
  garbage-collected. Caching one bounded pool per worker child gives a
  **predictable, explicitly-bounded footprint** and removes per-task connection
  churn — which matters most against a shared/external database.
- **Benchmarking (`bluecore-stack/scripts/bench`) could not reproduce connection
  exhaustion via the archive-loader path** at production concurrency, with or
  without injected network latency — `main` self-limits because GC reclaims
  abandoned pools about as fast as tasks create them. So this change is **safe with
  no measured regression** (throughput identical across branches), but is not
  claimed to be *the* fix.

## Production context (still under investigation)

The real incident was `FATAL: sorry, too many clients already` against a **shared,
external** Postgres (`bluecore-db-dev`, `max_connections=300`), triggered by two
parallel `archived_file_loader` runs. That points at **shared-headroom
exhaustion** across all clients on that server (Airflow's own pools, `bc_api`,
other apps), not this workflow opening 300 connections alone. Bounding this
workflow's pool is one contributing lever; the broader fix (PgBouncer / smaller
Airflow SQL pools / more headroom) is tracked separately, to be informed by a live
`pg_stat_activity` breakdown of the server under load.

## Notes

- Only the load paths are affected; there is a single `create_engine` call site
  now, inside `get_engine`.
- An alternative branch (`engine-dispose`) instead disposes the engine after each
  task (zero idle footprint, but keeps per-task pool creation); kept for
  comparison.

## Tests

- Adds `test_get_engine_caches_per_url` and an autouse fixture clearing the cache
  between tests.
- `tests/tasks/test_bluecore.py`: 10 passing; ruff + mypy clean; CI (build +
  stack-integration) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
