### PR TITLE
Skip needless Other Resource re-writes in the bulk CBD loader

### DIFF
--- a/ils_middleware/tasks/bluecore.py
+++ b/ils_middleware/tasks/bluecore.py
@@ -207,7 +207,16 @@ def load_cbd_files(
             # to see if deadlock continues
             for attempt in range(3):
                 try:
-                    save_graph(session_maker, graph, namespace=bc_url)
+                    # Bulk load: Works/Instances are authoritative, but the many
+                    # shared Other Resources these records reference are only
+                    # linked, not re-described, on every record (their
+                    # descriptions are maintained by a separate process).
+                    save_graph(
+                        session_maker,
+                        graph,
+                        namespace=bc_url,
+                        update_other_resources=False,
+                    )
                     break
                 except OperationalError as e:
                     if attempt == 2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pendulum",
     "psycopg2-binary>=2.9.10",
     "boto3",
-    "bluecore-models",
+    "bluecore-models>=0.25.0",
     "xmlsec==1.3.14", # this pin can be released once a package issue with 1.3.15 is resolved
     "apache-airflow-providers-keycloak>=0.8.1",
 ]


### PR DESCRIPTION
## Summary

`load_cbd_files` (the bulk CBD loader) now calls
`save_graph(..., update_other_resources=False)`.

Real CBD records reference many shared Other Resources (~26 per record vs. 1
Work + 1 Instance), and re-assigning `obj.data` re-runs the expensive JSON-LD
framing even when the description hasn't changed. With this flag the bulk path
**links** those Other Resources without **re-describing** them on every record
(their descriptions are maintained by a separate process), while Works and
Instances remain authoritative.

The single-record `load()` path is intentionally left unchanged (it's not the
bulk path).

## Depends on

- blue-core-lod/bluecore-models#138 — adds the `update_other_resources`
  parameter to `save_graph` (released in bluecore-models 0.25.0). **Must merge
  and release before this.** `pyproject.toml` now requires
  `bluecore-models>=0.25.0`.

## ⚠️ Before merging

`uv.lock` still pins `bluecore-models==0.24.0` and cannot be regenerated until
`0.25.0` is published to PyPI (until then `>=0.25.0` is unsatisfiable and CI
`--locked` checks will fail). Once the models release lands, run `uv lock` and
push the updated lockfile to this branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)