### PR TITLE
Remove basicConfig to fix duplicated log messages in Airflow

### DIFF
--- a/ils_middleware/tasks/bluecore.py
+++ b/ils_middleware/tasks/bluecore.py
@@ -21,8 +21,6 @@ logging.getLogger("rdflib").setLevel(logging.ERROR)
 logging.getLogger("bluecore_models").setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO)
 
 
 # Pool sizing per engine (i.e. per Celery worker child process). The load tasks


### PR DESCRIPTION
## Why was this change made?

logging.basicConfig() added a StreamHandler to the root logger. Under
Airflow, task logging is already configured and captures records that
propagate up from the module logger, so every log line was emitted twice.
Removing the basicConfig block lets Airflow own logging, so each line is
logged once.

## How was this change tested?

local testing

## Which documentation and/or configurations were updated?

n/a

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


