### PR TITLE
Replace DLC auto-assigner with CBC for single record MARC2BF

### DIFF
--- a/ils_middleware/dags/marc2bf.py
+++ b/ils_middleware/dags/marc2bf.py
@@ -6,7 +6,11 @@ from datetime import datetime
 from airflow.sdk import dag, get_current_context, task
 
 from ils_middleware.tasks.bluecore import delete_upload
-from ils_middleware.tasks.general.marc import convert_to_xml, xslt_marc_to_bf
+from ils_middleware.tasks.general.marc import (
+    convert_to_xml,
+    replace_dlc_assigner,
+    xslt_marc_to_bf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +63,7 @@ def marc_to_bibframe():
         Transforms MARC XML to BIBFRAME RDF XML using LOC's marc2bibframe2 XSLT
         """
         bf_rdf_xml = xslt_marc_to_bf(marc_xml, source_base_uri)
-        return bf_rdf_xml
+        return replace_dlc_assigner(bf_rdf_xml)
 
     @task
     def save_output(bf_rdf_xml: str, outputs_dir: str = "/opt/airflow/outputs") -> str:

--- a/ils_middleware/tasks/general/marc.py
+++ b/ils_middleware/tasks/general/marc.py
@@ -12,13 +12,23 @@ MARC2BIBFRAME2_XSL = (
 DLC_ORG_URI = "http://id.loc.gov/vocabulary/organizations/dlc"
 CBC_ORG_URI = "http://id.loc.gov/vocabulary/organizations/cbc"
 
+BF_NS = "http://id.loc.gov/ontologies/bibframe/"
+RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+
 
 def replace_dlc_assigner(bf_rdf_xml: str) -> str:
     """
-    Replace all occurrences of the DLC organization URI with the CBC
-    organization URI in the BIBFRAME RDF XML output.
+    Replace the DLC organization URI with CBC, but only on bf:assigner
+    elements inside bf:AdminMetadata nodes. Other uses of the DLC URI
+    (e.g. in bf:identifiedBy) are left unchanged.
     """
-    return bf_rdf_xml.replace(DLC_ORG_URI, CBC_ORG_URI)
+    root = ET.fromstring(bf_rdf_xml.encode("utf-8"))
+    for admin_md in root.iter(f"{{{BF_NS}}}AdminMetadata"):
+        for assigner in admin_md.iter(f"{{{BF_NS}}}assigner"):
+            resource = assigner.get(f"{{{RDF_NS}}}resource")
+            if resource == DLC_ORG_URI:
+                assigner.set(f"{{{RDF_NS}}}resource", CBC_ORG_URI)
+    return ET.tostring(root, pretty_print=True, encoding="unicode")
 
 
 def convert_to_xml(marc_file: str) -> str:

--- a/ils_middleware/tasks/general/marc.py
+++ b/ils_middleware/tasks/general/marc.py
@@ -9,6 +9,18 @@ MARC2BIBFRAME2_XSL = (
 )
 
 
+DLC_ORG_URI = "http://id.loc.gov/vocabulary/organizations/dlc"
+CBC_ORG_URI = "http://id.loc.gov/vocabulary/organizations/cbc"
+
+
+def replace_dlc_assigner(bf_rdf_xml: str) -> str:
+    """
+    Replace all occurrences of the DLC organization URI with the CBC
+    organization URI in the BIBFRAME RDF XML output.
+    """
+    return bf_rdf_xml.replace(DLC_ORG_URI, CBC_ORG_URI)
+
+
 def convert_to_xml(marc_file: str) -> str:
     """
     Convert MARC21 to MARC XML

--- a/tests/tasks/general/test_marc.py
+++ b/tests/tasks/general/test_marc.py
@@ -1,6 +1,13 @@
 import pytest
 
-from ils_middleware.tasks.general.marc import convert_to_xml, xslt_marc_to_bf
+from ils_middleware.tasks.general.marc import (
+    convert_to_xml,
+    replace_dlc_assigner,
+    xslt_marc_to_bf,
+)
+
+DLC_URI = "http://id.loc.gov/vocabulary/organizations/dlc"
+CBC_URI = "http://id.loc.gov/vocabulary/organizations/cbc"
 
 RECORD_MAR = "tests/fixtures/record.mar"
 RECORD_XML = "tests/fixtures/record.xml"
@@ -63,3 +70,36 @@ def test_convert_to_xml_then_xslt_marc_to_bf_roundtrip():
 
     assert isinstance(bf_rdf_xml, str)
     assert "<rdf:RDF" in bf_rdf_xml
+
+
+def test_replace_dlc_assigner_replaces_dlc_with_cbc():
+    rdf_xml = f'<bf:assigner rdf:resource="{DLC_URI}"/>'
+
+    result = replace_dlc_assigner(rdf_xml)
+
+    assert DLC_URI not in result
+    assert CBC_URI in result
+
+
+def test_replace_dlc_assigner_preserves_other_assigners():
+    other_uri = "http://id.loc.gov/vocabulary/organizations/cst"
+    rdf_xml = f'<bf:assigner rdf:resource="{other_uri}"/>'
+
+    result = replace_dlc_assigner(rdf_xml)
+
+    assert other_uri in result
+    assert CBC_URI not in result
+
+
+def test_replace_dlc_assigner_replaces_all_occurrences():
+    rdf_xml = (
+        f'<bf:assigner rdf:resource="{DLC_URI}"/>\n'
+        f'<bf:Agent rdf:about="{DLC_URI}"/>\n'
+        f'<bf:assigner rdf:resource="http://id.loc.gov/vocabulary/organizations/pu"/>'
+    )
+
+    result = replace_dlc_assigner(rdf_xml)
+
+    assert DLC_URI not in result
+    assert result.count(CBC_URI) == 2
+    assert "http://id.loc.gov/vocabulary/organizations/pu" in result

--- a/tests/tasks/general/test_marc.py
+++ b/tests/tasks/general/test_marc.py
@@ -72,8 +72,34 @@ def test_convert_to_xml_then_xslt_marc_to_bf_roundtrip():
     assert "<rdf:RDF" in bf_rdf_xml
 
 
-def test_replace_dlc_assigner_replaces_dlc_with_cbc():
-    rdf_xml = f'<bf:assigner rdf:resource="{DLC_URI}"/>'
+RDF_TEMPLATE = """<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:bf="http://id.loc.gov/ontologies/bibframe/">
+  {body}
+</rdf:RDF>"""
+
+
+def _admin_metadata_with_assigner(uri):
+    return f"""<bf:adminMetadata>
+      <bf:AdminMetadata>
+        <bf:identifiedBy>
+          <bf:Local>
+            <bf:assigner rdf:resource="{uri}"/>
+          </bf:Local>
+        </bf:identifiedBy>
+      </bf:AdminMetadata>
+    </bf:adminMetadata>"""
+
+
+def _identified_by_with_assigner(uri):
+    return f"""<bf:identifiedBy>
+      <bf:Local>
+        <bf:assigner rdf:resource="{uri}"/>
+      </bf:Local>
+    </bf:identifiedBy>"""
+
+
+def test_replace_dlc_assigner_replaces_dlc_inside_admin_metadata():
+    rdf_xml = RDF_TEMPLATE.format(body=_admin_metadata_with_assigner(DLC_URI))
 
     result = replace_dlc_assigner(rdf_xml)
 
@@ -81,9 +107,18 @@ def test_replace_dlc_assigner_replaces_dlc_with_cbc():
     assert CBC_URI in result
 
 
-def test_replace_dlc_assigner_preserves_other_assigners():
+def test_replace_dlc_assigner_preserves_dlc_outside_admin_metadata():
+    rdf_xml = RDF_TEMPLATE.format(body=_identified_by_with_assigner(DLC_URI))
+
+    result = replace_dlc_assigner(rdf_xml)
+
+    assert DLC_URI in result
+    assert CBC_URI not in result
+
+
+def test_replace_dlc_assigner_preserves_other_assigners_in_admin_metadata():
     other_uri = "http://id.loc.gov/vocabulary/organizations/cst"
-    rdf_xml = f'<bf:assigner rdf:resource="{other_uri}"/>'
+    rdf_xml = RDF_TEMPLATE.format(body=_admin_metadata_with_assigner(other_uri))
 
     result = replace_dlc_assigner(rdf_xml)
 
@@ -91,15 +126,16 @@ def test_replace_dlc_assigner_preserves_other_assigners():
     assert CBC_URI not in result
 
 
-def test_replace_dlc_assigner_replaces_all_occurrences():
-    rdf_xml = (
-        f'<bf:assigner rdf:resource="{DLC_URI}"/>\n'
-        f'<bf:Agent rdf:about="{DLC_URI}"/>\n'
-        f'<bf:assigner rdf:resource="http://id.loc.gov/vocabulary/organizations/pu"/>'
+def test_replace_dlc_assigner_scoped_to_admin_metadata_only():
+    """DLC inside AdminMetadata is replaced; DLC outside is preserved."""
+    body = (
+        _admin_metadata_with_assigner(DLC_URI)
+        + "\n"
+        + _identified_by_with_assigner(DLC_URI)
     )
+    rdf_xml = RDF_TEMPLATE.format(body=body)
 
     result = replace_dlc_assigner(rdf_xml)
 
-    assert DLC_URI not in result
-    assert result.count(CBC_URI) == 2
-    assert "http://id.loc.gov/vocabulary/organizations/pu" in result
+    assert result.count(CBC_URI) == 1
+    assert result.count(DLC_URI) == 1


### PR DESCRIPTION
fixes #148 

Add a post-processing step in the marc2bf DAG that replaces all occurrences of http://id.loc.gov/vocabulary/organizations/dlc with http://id.loc.gov/vocabulary/organizations/cbc in the BIBFRAME RDF XML output, rather than modifying the upstream LC XSLT (which is an external dependency).

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?




